### PR TITLE
Preformatted ordered values to simplify comparison

### DIFF
--- a/src/main/java/digital/pragmatech/testing/ContextCacheEntry.java
+++ b/src/main/java/digital/pragmatech/testing/ContextCacheEntry.java
@@ -14,6 +14,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.test.context.MergedContextConfiguration;
 
+import static digital.pragmatech.testing.util.CollectionFormatUtils.prettyPrintCollection;
+import static digital.pragmatech.testing.util.CollectionFormatUtils.toStringSortedSet;
+
 /** Entry representing a cached context configuration. */
 public class ContextCacheEntry {
   private final MergedContextConfiguration configuration;
@@ -199,22 +202,33 @@ public class ContextCacheEntry {
     Map<String, Object> summary = new LinkedHashMap<>();
 
     if (configuration != null) {
-
+      // configurationClasses equality is based on ordered Class<?>[]
       summary.put(
           "configurationClasses",
-          Arrays.stream(configuration.getClasses()).map(Class::getSimpleName).toList());
+          prettyPrintCollection(
+              Arrays.stream(configuration.getClasses()).map(Class::getName).toList()));
 
-      summary.put("activeProfiles", Arrays.asList(configuration.getActiveProfiles()));
+      // activeProfiles equality is based on ordered String[]
+      summary.put(
+          "activeProfiles",
+          prettyPrintCollection(Arrays.asList(configuration.getActiveProfiles())));
       summary.put("contextLoader", configuration.getContextLoader().getClass().getSimpleName());
-
       summary.put("properties", configuration.getPropertySourceProperties().length + " properties");
       summary.put("parentContext", configuration.getParent());
-      summary.put("contextCustomizers", configuration.getContextCustomizers());
-      summary.put("locations", String.join(",", configuration.getLocations()));
+      // contextCustomizers equality is based on Set. Convert to ordered String representation to
+      // simplify comparison
+      summary.put(
+          "contextCustomizers",
+          prettyPrintCollection(toStringSortedSet(configuration.getContextCustomizers())));
+      // locations equality is based on ordered String[]
+      summary.put("locations", prettyPrintCollection(Arrays.asList(configuration.getLocations())));
 
+      // contextInitializers equality is based on Set. Convert to ordered String representation to
+      // simplify comparison
       summary.put(
           "contextInitializers",
-          configuration.getContextInitializerClasses().stream().map(Class::getSimpleName).toList());
+          prettyPrintCollection(
+              configuration.getContextInitializerClasses().stream().map(Class::getName).toList()));
 
       summary.put("beanDefinitionCount", beanDefinitionCount);
     }

--- a/src/main/java/digital/pragmatech/testing/util/CollectionFormatUtils.java
+++ b/src/main/java/digital/pragmatech/testing/util/CollectionFormatUtils.java
@@ -1,0 +1,43 @@
+package digital.pragmatech.testing.util;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public final class CollectionFormatUtils {
+
+  /**
+   * Convert collection of objects to SortedSet of String. This can be helpful for visually
+   * comparable representations.
+   *
+   * @param elements
+   * @return
+   */
+  public static SortedSet<String> toStringSortedSet(Collection<?> elements) {
+    var set = new TreeSet<String>();
+    elements.forEach(e -> set.add(Objects.toString(e)));
+    return set;
+  }
+
+  /**
+   * Pretty format collection elements (new line for each element).
+   *
+   * @param elements
+   * @return
+   */
+  public static String prettyPrintCollection(Collection<String> elements) {
+    if (elements == null) {
+      return "";
+    }
+    if (elements.isEmpty()) {
+      return "[]";
+    }
+    if (elements.size() == 1) {
+      return "[" + elements.iterator().next() + "]";
+    }
+    return "[\n" + String.join(",\n", elements) + "\n]";
+  }
+
+  private CollectionFormatUtils() {}
+}

--- a/src/main/resources/templates/fragments/configurations.html
+++ b/src/main/resources/templates/fragments/configurations.html
@@ -30,7 +30,9 @@
         <div class="config-details">
           <div th:each="entry : ${configInfo.configuration.entrySet()}" class="config-detail-item">
             <div class="config-detail-key" th:text="${entry.key + ':'}">Key:</div>
-            <div class="config-detail-value" th:text="${entry.value}">Value</div>
+            <div class="config-detail-value">
+              <pre th:text="${entry.value}"></pre>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
Default visual representation of `MergedContextConfiguration` fields is not pretty friendly for visual comparison (which is assumed by the tool itself). This change suggests simple prototype how this can be implemented by using:
* ordering for elements that are compared as `Set` collection
* pretty formatting of collections
* using `<pre>` tag in the HTML

Sample new representation (pay attention to `contextCustomizers` field value):
<img width="1146" height="805" alt="Screenshot 2025-07-20 at 18 20 45" src="https://github.com/user-attachments/assets/79b279f3-37b4-4c1d-ae78-7f9cc4bb4173" />

Now this can be easily compared in text editor:
<img width="1433" height="402" alt="Screenshot 2025-07-20 at 18 21 37" src="https://github.com/user-attachments/assets/e28dd63c-48c2-409d-a6f4-96ef77475d83" />

Note that using `<pre>` also has disadvantages for long `toString` representations