### PR TITLE
refactor(report): externalize static CSS/JS assets instead of inline embedding

### DIFF
--- a/src/main/java/digital/pragmatech/testing/reporting/html/TestExecutionReporter.java
+++ b/src/main/java/digital/pragmatech/testing/reporting/html/TestExecutionReporter.java
@@ -58,6 +58,9 @@ public class TestExecutionReporter {
         jsonReportGenerator.generateJsonReport(
             reportDir, executionTracker, cacheStats, contextCacheTracker);
       } else {
+        // Copy static assets before generating HTML
+        copyStaticAssets(reportDir);
+
         // Original HTML reporting logic
         String timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER);
         String reportFileName = "test-profiler-report-" + timestamp + ".html";
@@ -199,13 +202,7 @@ public class TestExecutionReporter {
         context.setVariable("timelineData", timelineData);
       }
 
-      // Load CSS content
-      String cssContent = loadCssContent();
-      context.setVariable("cssContent", cssContent);
-
-      // Load JS content
-      String jsContent = loadJsContent();
-      context.setVariable("jsContent", jsContent);
+      // Static assets are now copied in generateReport method
 
       // Register helper beans for templates
       registerHelperBeans(context, contextCacheTracker);
@@ -246,36 +243,35 @@ public class TestExecutionReporter {
     context.setVariable("jsonHelper", new TemplateHelpers.JsonHelper());
   }
 
-  private String loadCssContent() {
+  private void copyStaticAssets(Path reportDir) {
     try {
-      // Use InputStream to read from classpath resource which works both in IDE and JAR
-      try (var inputStream =
-          getClass().getClassLoader().getResourceAsStream("static/css/spring-test-profiler.css")) {
-        if (inputStream == null) {
-          throw new RuntimeException(
-              "CSS file not found in classpath: static/css/spring-test-profiler.css");
-        }
-        return new String(inputStream.readAllBytes());
-      }
-    } catch (Exception e) {
-      logger.error("Could not load CSS file. Report generation will fail.", e);
-      throw new RuntimeException("CSS file not found", e);
+      // Create static directories
+      Path staticDir = reportDir.resolve("static");
+      Path cssDir = staticDir.resolve("css");
+      Path jsDir = staticDir.resolve("js");
+
+      Files.createDirectories(cssDir);
+      Files.createDirectories(jsDir);
+
+      // Copy CSS file
+      copyResourceToFile(
+          "static/css/spring-test-profiler.css", cssDir.resolve("spring-test-profiler.css"));
+
+      // Copy JS file
+      copyResourceToFile("static/js/report.js", jsDir.resolve("report.js"));
+
+    } catch (IOException e) {
+      logger.error("Failed to copy static assets to report directory", e);
+      throw new RuntimeException("Static asset copying failed", e);
     }
   }
 
-  private String loadJsContent() {
-    try {
-      // Use InputStream to read from classpath resource which works both in IDE and JAR
-      try (var inputStream =
-          getClass().getClassLoader().getResourceAsStream("static/js/report.js")) {
-        if (inputStream == null) {
-          throw new RuntimeException("JS file not found in classpath: static/js/report.js");
-        }
-        return new String(inputStream.readAllBytes());
+  private void copyResourceToFile(String resourcePath, Path targetFile) throws IOException {
+    try (var inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+      if (inputStream == null) {
+        throw new RuntimeException("Resource not found in classpath: " + resourcePath);
       }
-    } catch (Exception e) {
-      logger.error("Could not load JS file. Report generation will fail.", e);
-      throw new RuntimeException("JS file not found", e);
+      Files.copy(inputStream, targetFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
     }
   }
 }

--- a/src/main/resources/templates/report.html
+++ b/src/main/resources/templates/report.html
@@ -8,7 +8,7 @@
   <link rel="icon"
         href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧪</text></svg>">
   <script src="https://d3js.org/d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous"></script>
-  <style th:utext="${cssContent}"></style>
+  <link rel="stylesheet" href="static/css/spring-test-profiler.css">
 </head>
 <body>
 <div class="container">
@@ -72,6 +72,6 @@
 </footer>
 
 <script type="application/json" id="context-statistics-json" th:utext="${contextStatisticsJson}">[]</script>
-<script th:utext="${jsContent}"></script>
+<script src="static/js/report.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- Remove loadCssContent() and loadJsContent() methods from TestExecutionReporter
- Add copyStaticAssets() method to copy CSS/JS files to report directory
- Update HTML template to use external <link> and <script> references
- Maintain dynamic JSON context data as inline script
- Improve maintainability by separating static from dynamic content
- Report directory structure: static/css/ and static/js/ subdirectories

🤖 Generated with [Claude Code](https://claude.ai/code)