### PR TITLE
feat: introduce awaitility

### DIFF
--- a/demo/spring-boot-3.5-maven-failsafe-parallel/pom.xml
+++ b/demo/spring-boot-3.5-maven-failsafe-parallel/pom.xml
@@ -22,6 +22,7 @@
 
   <properties>
     <java.version>21</java.version>
+    <awaitility.version>4.3.0</awaitility.version>
   </properties>
 
 
@@ -51,6 +52,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/demo/spring-boot-3.5-maven-failsafe-parallel/src/test/java/digital/pragmatech/demo/BookRepositoryIT.java
+++ b/demo/spring-boot-3.5-maven-failsafe-parallel/src/test/java/digital/pragmatech/demo/BookRepositoryIT.java
@@ -2,7 +2,9 @@ package digital.pragmatech.demo;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import digital.pragmatech.demo.entity.Book;
 import digital.pragmatech.demo.entity.BookCategory;
 import digital.pragmatech.demo.repository.BookRepository;
@@ -30,7 +32,9 @@ public class BookRepositoryIT {
   @Test
   void testSaveAndFindBook() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(100);
+    Awaitility.await()
+      .pollDelay(100, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Clean Code", "Robert C. Martin", "978-0132350884",
       new BigDecimal("45.99"), BookCategory.TECHNOLOGY);
@@ -45,7 +49,9 @@ public class BookRepositoryIT {
   @Test
   void testFindByIsbn() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(150);
+    Awaitility.await()
+      .pollDelay(150, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Effective Java", "Joshua Bloch", "978-0134685991",
       new BigDecimal("52.99"), BookCategory.TECHNOLOGY);
@@ -60,7 +66,9 @@ public class BookRepositoryIT {
   @Test
   void testFindByCategory() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(120);
+    Awaitility.await()
+      .pollDelay(120, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book techBook = new Book("Design Patterns", "Gang of Four", "978-0201633612",
       new BigDecimal("59.99"), BookCategory.TECHNOLOGY);
@@ -79,7 +87,9 @@ public class BookRepositoryIT {
   @Test
   void testCountByCategory() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(80);
+    Awaitility.await()
+      .pollDelay(80, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book1 = new Book("Java Concurrency", "Brian Goetz", "978-0321349606",
       new BigDecimal("49.99"), BookCategory.TECHNOLOGY);

--- a/demo/spring-boot-3.5-maven-failsafe-parallel/src/test/java/digital/pragmatech/demo/BookServiceIT.java
+++ b/demo/spring-boot-3.5-maven-failsafe-parallel/src/test/java/digital/pragmatech/demo/BookServiceIT.java
@@ -31,7 +31,7 @@ class BookServiceIT {
   private BookService bookService;
 
   @Test
-  void testCreateBook() throws InterruptedException {
+  void testCreateBook() {
     // Simulate some processing time
     Awaitility.await()
       .pollDelay(90, TimeUnit.MILLISECONDS)
@@ -47,7 +47,7 @@ class BookServiceIT {
   }
 
   @Test
-  void testFindByAuthor() throws InterruptedException {
+  void testFindByAuthor() {
     // Simulate some processing time
     Awaitility.await()
       .pollDelay(110, TimeUnit.MILLISECONDS)
@@ -65,7 +65,7 @@ class BookServiceIT {
   }
 
   @Test
-  void testFindByPriceRange() throws InterruptedException {
+  void testFindByPriceRange() {
     // Simulate some processing time
     Awaitility.await()
       .pollDelay(130, TimeUnit.MILLISECONDS)
@@ -86,7 +86,7 @@ class BookServiceIT {
   }
 
   @Test
-  void testCountBooks() throws InterruptedException {
+  void testCountBooks() {
     // Simulate some processing time
     Awaitility.await()
       .pollDelay(70, TimeUnit.MILLISECONDS)

--- a/demo/spring-boot-3.5-maven-failsafe-parallel/src/test/java/digital/pragmatech/demo/BookServiceIT.java
+++ b/demo/spring-boot-3.5-maven-failsafe-parallel/src/test/java/digital/pragmatech/demo/BookServiceIT.java
@@ -2,7 +2,9 @@ package digital.pragmatech.demo;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import digital.pragmatech.demo.entity.Book;
 import digital.pragmatech.demo.entity.BookCategory;
 import digital.pragmatech.demo.service.BookService;
@@ -31,7 +33,9 @@ class BookServiceIT {
   @Test
   void testCreateBook() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(90);
+    Awaitility.await()
+      .pollDelay(90, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Microservices Patterns", "Chris Richardson", "978-1617294549",
       new BigDecimal("54.99"), BookCategory.TECHNOLOGY);
@@ -45,7 +49,9 @@ class BookServiceIT {
   @Test
   void testFindByAuthor() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(110);
+    Awaitility.await()
+      .pollDelay(110, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     String uniqueAuthor = "Craig Walls " + System.currentTimeMillis();
     Book book = new Book("Spring Boot in Action", uniqueAuthor, "978-1617292545",
@@ -61,7 +67,9 @@ class BookServiceIT {
   @Test
   void testFindByPriceRange() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(130);
+    Awaitility.await()
+      .pollDelay(130, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book1 = new Book("Affordable Book", "Author One", "978-1111111111",
       new BigDecimal("25.00"), BookCategory.TECHNOLOGY);
@@ -80,7 +88,9 @@ class BookServiceIT {
   @Test
   void testCountBooks() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(70);
+    Awaitility.await()
+      .pollDelay(70, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book1 = new Book("Book One", "Author", "978-3333333333",
       new BigDecimal("30.00"), BookCategory.TECHNOLOGY);

--- a/demo/spring-boot-3.5-maven-failsafe-parallel/src/test/java/digital/pragmatech/demo/DataLayerIT.java
+++ b/demo/spring-boot-3.5-maven-failsafe-parallel/src/test/java/digital/pragmatech/demo/DataLayerIT.java
@@ -3,7 +3,9 @@ package digital.pragmatech.demo;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import digital.pragmatech.demo.entity.Book;
 import digital.pragmatech.demo.entity.BookCategory;
 import digital.pragmatech.demo.repository.BookRepository;
@@ -36,7 +38,9 @@ public class DataLayerIT {
   @Test
   void testEntityPersistence() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(90);
+    Awaitility.await()
+      .pollDelay(90, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Hibernate in Action", "Christian Bauer", "978-1932394153",
       new BigDecimal("48.99"), BookCategory.TECHNOLOGY);
@@ -51,7 +55,9 @@ public class DataLayerIT {
   @Test
   void testFindByTitleContaining() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(110);
+    Awaitility.await()
+      .pollDelay(110, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book1 = new Book("Spring Framework Guide", "Author", "978-5555555555",
       new BigDecimal("35.00"), BookCategory.TECHNOLOGY);
@@ -74,7 +80,9 @@ public class DataLayerIT {
   @Test
   void testExistsById() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(70);
+    Awaitility.await()
+      .pollDelay(70, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("JPA Essentials", "Author", "978-8888888888",
       new BigDecimal("42.00"), BookCategory.TECHNOLOGY);
@@ -88,7 +96,9 @@ public class DataLayerIT {
   @Test
   void testDeleteByIsbn() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(130);
+    Awaitility.await()
+      .pollDelay(130, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Database Design", "Author", "978-9999999999",
       new BigDecimal("38.00"), BookCategory.TECHNOLOGY);

--- a/demo/spring-boot-3.5-maven-failsafe-parallel/src/test/java/digital/pragmatech/demo/WebLayerIT.java
+++ b/demo/spring-boot-3.5-maven-failsafe-parallel/src/test/java/digital/pragmatech/demo/WebLayerIT.java
@@ -1,7 +1,9 @@
 package digital.pragmatech.demo;
 
 import java.math.BigDecimal;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import digital.pragmatech.demo.entity.Book;
 import digital.pragmatech.demo.entity.BookCategory;
 import org.junit.jupiter.api.Test;
@@ -35,7 +37,9 @@ public class WebLayerIT {
   @Test
   void testCreateBookEndpoint() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(100);
+    Awaitility.await()
+      .pollDelay(100, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     String uniqueIsbn = "978-0596529" + System.currentTimeMillis() % 1000;
     Book book = new Book("RESTful Web Services", "Leonard Richardson", uniqueIsbn,
@@ -51,7 +55,9 @@ public class WebLayerIT {
   @Test
   void testGetAllBooksEndpoint() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(120);
+    Awaitility.await()
+      .pollDelay(120, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     // First create a book
     String uniqueIsbn = "978-1617295" + System.currentTimeMillis() % 1000;
@@ -69,7 +75,9 @@ public class WebLayerIT {
   @Test
   void testGetBookCountEndpoint() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(80);
+    Awaitility.await()
+      .pollDelay(80, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     ResponseEntity<Long> response = testRestTemplate.getForEntity("/api/books/count", Long.class);
 
@@ -81,7 +89,9 @@ public class WebLayerIT {
   @Test
   void testSearchBooksEndpoint() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(140);
+    Awaitility.await()
+      .pollDelay(140, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     // Create a book first
     String uniqueAuthor = "Kent Beck " + System.currentTimeMillis();

--- a/demo/spring-boot-3.5-maven-junit-parallel/pom.xml
+++ b/demo/spring-boot-3.5-maven-junit-parallel/pom.xml
@@ -22,6 +22,7 @@
 
   <properties>
     <java.version>21</java.version>
+    <awaitility.version>4.3.0</awaitility.version>
   </properties>
 
   <dependencies>
@@ -50,6 +51,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/demo/spring-boot-3.5-maven-junit-parallel/src/test/java/digital/pragmatech/demo/BookRepositoryParallelIT.java
+++ b/demo/spring-boot-3.5-maven-junit-parallel/src/test/java/digital/pragmatech/demo/BookRepositoryParallelIT.java
@@ -2,7 +2,9 @@ package digital.pragmatech.demo;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import digital.pragmatech.demo.entity.Book;
 import digital.pragmatech.demo.entity.BookCategory;
 import digital.pragmatech.demo.repository.BookRepository;
@@ -33,7 +35,9 @@ public class BookRepositoryParallelIT {
   @Test
   void testSaveAndFindBookParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(120);
+    Awaitility.await()
+      .pollDelay(120, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Clean Architecture", "Robert C. Martin", "978-0134494166",
       new BigDecimal("48.99"), BookCategory.TECHNOLOGY);
@@ -48,7 +52,9 @@ public class BookRepositoryParallelIT {
   @Test
   void testFindByIsbnParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(100);
+    Awaitility.await()
+      .pollDelay(100, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Java: The Complete Reference", "Herbert Schildt", "978-1260440232",
       new BigDecimal("59.99"), BookCategory.TECHNOLOGY);
@@ -63,7 +69,9 @@ public class BookRepositoryParallelIT {
   @Test
   void testFindByAuthorParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(90);
+    Awaitility.await()
+      .pollDelay(90, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book1 = new Book("Spring Security in Action", "Laurentiu Spilca", "978-1617297731",
       new BigDecimal("49.99"), BookCategory.TECHNOLOGY);
@@ -81,7 +89,9 @@ public class BookRepositoryParallelIT {
   @Test
   void testFindByPriceBetweenParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(110);
+    Awaitility.await()
+      .pollDelay(110, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book1 = new Book("Budget Book", "Author", "978-1111111111",
       new BigDecimal("15.00"), BookCategory.FICTION);

--- a/demo/spring-boot-3.5-maven-junit-parallel/src/test/java/digital/pragmatech/demo/BookServiceParallelIT.java
+++ b/demo/spring-boot-3.5-maven-junit-parallel/src/test/java/digital/pragmatech/demo/BookServiceParallelIT.java
@@ -2,7 +2,9 @@ package digital.pragmatech.demo;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import digital.pragmatech.demo.entity.Book;
 import digital.pragmatech.demo.entity.BookCategory;
 import digital.pragmatech.demo.service.BookService;
@@ -34,7 +36,9 @@ public class BookServiceParallelIT {
   @Test
   void testCreateBookParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(95);
+    Awaitility.await()
+      .pollDelay(95, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Domain-Driven Design", "Eric Evans", "978-0321125215",
       new BigDecimal("56.99"), BookCategory.TECHNOLOGY);
@@ -48,7 +52,9 @@ public class BookServiceParallelIT {
   @Test
   void testUpdateBookParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(85);
+    Awaitility.await()
+      .pollDelay(85, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Original Title", "Author", "978-4444444444",
       new BigDecimal("30.00"), BookCategory.TECHNOLOGY);
@@ -66,7 +72,9 @@ public class BookServiceParallelIT {
   @Test
   void testFindByTitleParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(105);
+    Awaitility.await()
+      .pollDelay(105, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Refactoring: Improving Design", "Martin Fowler", "978-0134757599",
       new BigDecimal("47.99"), BookCategory.TECHNOLOGY);
@@ -81,7 +89,9 @@ public class BookServiceParallelIT {
   @Test
   void testDeleteBookParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(75);
+    Awaitility.await()
+      .pollDelay(75, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Temporary Book", "Author", "978-5555555555",
       new BigDecimal("25.00"), BookCategory.TECHNOLOGY);

--- a/demo/spring-boot-3.5-maven-junit-parallel/src/test/java/digital/pragmatech/demo/BookServiceParallelIT.java
+++ b/demo/spring-boot-3.5-maven-junit-parallel/src/test/java/digital/pragmatech/demo/BookServiceParallelIT.java
@@ -34,7 +34,7 @@ public class BookServiceParallelIT {
   private BookService bookService;
 
   @Test
-  void testCreateBookParallel() throws InterruptedException {
+  void testCreateBookParallel() {
     // Simulate some processing time
     Awaitility.await()
       .pollDelay(95, TimeUnit.MILLISECONDS)
@@ -50,7 +50,7 @@ public class BookServiceParallelIT {
   }
 
   @Test
-  void testUpdateBookParallel() throws InterruptedException {
+  void testUpdateBookParallel() {
     // Simulate some processing time
     Awaitility.await()
       .pollDelay(85, TimeUnit.MILLISECONDS)
@@ -70,7 +70,7 @@ public class BookServiceParallelIT {
   }
 
   @Test
-  void testFindByTitleParallel() throws InterruptedException {
+  void testFindByTitleParallel() {
     // Simulate some processing time
     Awaitility.await()
       .pollDelay(105, TimeUnit.MILLISECONDS)
@@ -87,7 +87,7 @@ public class BookServiceParallelIT {
   }
 
   @Test
-  void testDeleteBookParallel() throws InterruptedException {
+  void testDeleteBookParallel() {
     // Simulate some processing time
     Awaitility.await()
       .pollDelay(75, TimeUnit.MILLISECONDS)

--- a/demo/spring-boot-3.5-maven-junit-parallel/src/test/java/digital/pragmatech/demo/DatabaseParallelIT.java
+++ b/demo/spring-boot-3.5-maven-junit-parallel/src/test/java/digital/pragmatech/demo/DatabaseParallelIT.java
@@ -2,7 +2,9 @@ package digital.pragmatech.demo;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import digital.pragmatech.demo.entity.Book;
 import digital.pragmatech.demo.entity.BookCategory;
 import digital.pragmatech.demo.repository.BookRepository;
@@ -42,7 +44,9 @@ public class DatabaseParallelIT {
   @Test
   void testEntityManagerPersistenceParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(78);
+    Awaitility.await()
+      .pollDelay(78, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Effective Java 3rd Edition", "Joshua Bloch", "978-0134685991",
       new BigDecimal("54.99"), BookCategory.TECHNOLOGY);
@@ -56,7 +60,9 @@ public class DatabaseParallelIT {
   @Test
   void testRepositoryCountParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(92);
+    Awaitility.await()
+      .pollDelay(92, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book1 = new Book("Book A", "Author A", "978-1111111111",
       new BigDecimal("25.00"), BookCategory.FICTION);
@@ -74,7 +80,9 @@ public class DatabaseParallelIT {
   @Test
   void testQueryByExampleParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(108);
+    Awaitility.await()
+      .pollDelay(108, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book techBook1 = new Book("Spring Boot Guide", "Author", "978-3333333333",
       new BigDecimal("45.00"), BookCategory.TECHNOLOGY);
@@ -96,7 +104,9 @@ public class DatabaseParallelIT {
   @Test
   void testTransactionalBehaviorParallel() throws InterruptedException {
     // Simulate some processing time
-    Thread.sleep(135);
+    Awaitility.await()
+      .pollDelay(135, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     Book book = new Book("Transaction Test", "Author", "978-6666666666",
       new BigDecimal("35.00"), BookCategory.TECHNOLOGY);

--- a/demo/spring-boot-3.5-maven-junit-parallel/src/test/java/digital/pragmatech/demo/WebMvcParallelIT.java
+++ b/demo/spring-boot-3.5-maven-junit-parallel/src/test/java/digital/pragmatech/demo/WebMvcParallelIT.java
@@ -1,5 +1,8 @@
 package digital.pragmatech.demo;
 
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -41,7 +44,9 @@ public class WebMvcParallelIT {
   @Test
   void testCreateBookMvcParallel() throws Exception {
     // Simulate some processing time
-    Thread.sleep(88);
+    Awaitility.await()
+      .pollDelay(88, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
 
@@ -65,7 +70,9 @@ public class WebMvcParallelIT {
   @Test
   void testGetAllBooksMvcParallel() throws Exception {
     // Simulate some processing time
-    Thread.sleep(115);
+    Awaitility.await()
+      .pollDelay(115, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
 
@@ -78,7 +85,9 @@ public class WebMvcParallelIT {
   @Test
   void testGetBookCountMvcParallel() throws Exception {
     // Simulate some processing time
-    Thread.sleep(65);
+    Awaitility.await()
+      .pollDelay(65, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
 
@@ -90,7 +99,9 @@ public class WebMvcParallelIT {
   @Test
   void testSearchBooksMvcParallel() throws Exception {
     // Simulate some processing time
-    Thread.sleep(125);
+    Awaitility.await()
+      .pollDelay(125, TimeUnit.MILLISECONDS)
+      .until(() -> true);
 
     mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <junit-jupiter.version>5.13.2</junit-jupiter.version>
     <assertj.version>3.26.3</assertj.version>
+    <awaitility.version>4.3.0</awaitility.version>
 
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
@@ -97,6 +98,12 @@
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/test/java/digital/pragmatech/testing/context/SlowContextInitializer.java
+++ b/src/test/java/digital/pragmatech/testing/context/SlowContextInitializer.java
@@ -1,5 +1,8 @@
 package digital.pragmatech.testing.context;
 
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 
@@ -8,10 +11,8 @@ public class SlowContextInitializer
 
   @Override
   public void initialize(ConfigurableApplicationContext applicationContext) {
-    try {
-      Thread.sleep(2000); // Simulate a slow initialization
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
+    Awaitility.await()
+        .pollDelay(1, TimeUnit.SECONDS)
+        .until(() -> true); // Simulate a slow initialization
   }
 }


### PR DESCRIPTION
Currently, `thread.sleep` is used, which is best avoided and leads to complaints in SonarQube.
This PR introduces awaitility to resolve this.