### PR TITLE
feat(core): single registerSingleton to avoid duplication

### DIFF
--- a/src/main/java/digital/pragmatech/testing/diagnostic/ContextDiagnosticApplicationInitializer.java
+++ b/src/main/java/digital/pragmatech/testing/diagnostic/ContextDiagnosticApplicationInitializer.java
@@ -30,4 +30,16 @@ public class ContextDiagnosticApplicationInitializer
           }
         });
   }
+
+  @Override
+  public boolean equals(Object that) {
+    // avoid double registration of the same bean when listener was discovered via
+    // spring.factories
+    return getClass() == that.getClass();
+  }
+
+  @Override
+  public int hashCode() {
+    return 0;
+  }
 }


### PR DESCRIPTION
There is a scenario when `ContextDiagnosticApplicationInitializer` is specified in both `spring.factories` discovered in the classpath and specified explicitly on the class. In this case test execution fails with
```
19:23:47 [main] ERROR org.springframework.boot.SpringApplication - Application run failed
java.lang.IllegalStateException: Could not register object [ContextDiagnostic[contextLoadStartTime=1754853753835, contextLoadEndTime=1754853827194, contextLoadComplete=true, heapMemoryUsedBytes=134002912, nonHeapMemoryUsedBytes=60453496, availableProcessors=12, totalMemoryBytes=226492416, maxMemoryBytes=6442450944, freeMemoryBytes=92055928]] under bean name 'contextDiagnostic': there is already object [ContextDiagnostic[contextLoadStartTime=1754853753830, contextLoadEndTime=1754853827194, contextLoadComplete=true, heapMemoryUsedBytes=134002912, nonHeapMemoryUsedBytes=60432104, availableProcessors=12, totalMemoryBytes=226492416, maxMemoryBytes=6442450944, freeMemoryBytes=92055928]] bound
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.registerSingleton(DefaultSingletonBeanRegistry.java:124)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.registerSingleton(DefaultListableBeanFactory.java:1175)
	at digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer.lambda$initialize$0(ContextDiagnosticApplicationInitializer.java:34)
```
and this failure is pretty unclear as test eventually fails with other diagnostics (if the suite is heavy and big). This simple fix makes the singleton registration conditional to do it not more than once.