### PR TITLE
feat(report): add diff library to improve comparison feature

### DIFF
--- a/src/main/resources/static/css/spring-test-profiler.css
+++ b/src/main/resources/static/css/spring-test-profiler.css
@@ -1504,7 +1504,6 @@ h2 {
     max-height: 400px;
     overflow-y: auto;
     overflow-x: auto;
-    white-space: pre-wrap;
 }
 
 .context-detail-value:empty {
@@ -1749,4 +1748,74 @@ h2 {
         align-items: flex-start;
         gap: 5px;
     }
+}
+
+.diff-container {
+    border: 1px solid #d0d7de;
+    overflow: hidden;
+    font-size: 12px;
+}
+
+.difference-container {
+    display: flex;
+    gap: 20px;
+}
+
+.diff-column {
+    max-height: 300px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    background: #fefefe;
+    padding: 5px;
+    font-family: monospace;
+    flex: 1;
+}
+
+.symbol {
+    text-align: center;
+    font-weight: bold;
+}
+
+.num {
+    display: flex;
+    justify-content: flex-end;
+    width: 40px;
+    color: #656d76;
+    margin-right: 8px;
+    padding: 0 8px;
+    flex-shrink: 0;
+    border-right: 1px solid #d0d7de;
+    min-width: 30px;
+    text-align: right;
+}
+
+.code {
+    flex: 1;
+    padding: 2px 6px;
+}
+
+.same {
+    display: flex;
+    background-color: #f6f8fa;
+    border-left: 3px solid #d0d7de;
+    min-height: 20px;
+}
+
+.different {
+    display: flex;
+    align-items: center;
+    background-color: #f6f8fa;
+    border-left: 3px solid #d0d7de;
+    min-height: 20px;
+}
+
+.empty {
+    background: #fefefe;
+}
+
+.empty-line {
+    background-color: #f8f9fa;
+    border-left: 3px solid #dee2e6;
+    min-height: 20px;
 }

--- a/src/main/resources/templates/report.html
+++ b/src/main/resources/templates/report.html
@@ -8,6 +8,7 @@
   <link rel="icon"
         href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧪</text></svg>">
   <script src="https://d3js.org/d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/diff@5.2.0/dist/diff.min.js"></script>
   <link rel="stylesheet" href="static/css/spring-test-profiler.css">
 </head>
 <body>

--- a/src/main/resources/templates/report.html
+++ b/src/main/resources/templates/report.html
@@ -8,7 +8,7 @@
   <link rel="icon"
         href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧪</text></svg>">
   <script src="https://d3js.org/d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/diff@5.2.0/dist/diff.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/diff@5.2.0/dist/diff.min.js" integrity="lJJVaUgxmk/PVfQnAsGN1QuJZrE+n6bg2EMu33yVZOJ2av/3UzTHbmnPCI7ENJYa" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="static/css/spring-test-profiler.css">
 </head>
 <body>


### PR DESCRIPTION
The default visual representation in the Detailed Comparison section is not very intuitive for visually identifying differences between contexts.

This change introduces the use of the [diff](https://www.npmjs.com/package/diff) library to provide a clearer visualization, highlighting which values have been added, removed, or modified. The goal is to make comparing the contents of both contexts simpler and more straightforward.

### Current visualization 
<img width="1114" height="556" alt="image" src="https://github.com/user-attachments/assets/46114144-6fb8-4279-ada2-5dc44cf15061" />

### Proposed visualization
<img width="1159" height="514" alt="image" src="https://github.com/user-attachments/assets/98f22047-bd4b-4c90-93c9-502f8332f00f" />

