### PR TITLE
Fixes an issue with the contextDiagnostic being registered multiple times

### DIFF
--- a/src/main/java/digital/pragmatech/testing/diagnostic/ContextDiagnosticApplicationInitializer.java
+++ b/src/main/java/digital/pragmatech/testing/diagnostic/ContextDiagnosticApplicationInitializer.java
@@ -21,12 +21,15 @@ public class ContextDiagnosticApplicationInitializer
 
     applicationContext.addApplicationListener(
         event -> {
-          if (event instanceof ContextRefreshedEvent) {
-            ContextDiagnostic completedDiagnostic = contextDiagnostic.completed();
-            applicationContext
-                .getBeanFactory()
-                .registerSingleton("contextDiagnostic", completedDiagnostic);
-            LOG.debug("Context Diagnostic Completed: {}", completedDiagnostic);
+          if (event instanceof ContextRefreshedEvent contextEvent) {
+            if (contextEvent.getApplicationContext().getParent() == null
+                && !applicationContext.getBeanFactory().containsSingleton("contextDiagnostic")) {
+              ContextDiagnostic completedDiagnostic = contextDiagnostic.completed();
+              applicationContext
+                  .getBeanFactory()
+                  .registerSingleton("contextDiagnostic", completedDiagnostic);
+              LOG.debug("Context Diagnostic Completed: {}", completedDiagnostic);
+            }
           }
         });
   }

--- a/src/test/java/digital/pragmatech/testing/diagnostic/ContextDiagnosticApplicationInitializerTest.java
+++ b/src/test/java/digital/pragmatech/testing/diagnostic/ContextDiagnosticApplicationInitializerTest.java
@@ -1,0 +1,85 @@
+package digital.pragmatech.testing.diagnostic;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContextDiagnosticApplicationInitializerTest {
+
+  @Test
+  void shouldRegisterBeanInParentContextOnly() {
+    // Create parent context
+    var parentContext = new AnnotationConfigApplicationContext();
+
+    var initializer = new ContextDiagnosticApplicationInitializer();
+    initializer.initialize(parentContext);
+
+    // Refresh parent context - should register bean
+    parentContext.refresh();
+
+    assertThat(parentContext.containsBean("contextDiagnostic")).isTrue();
+
+    // Create child context
+    AnnotationConfigApplicationContext childContext = new AnnotationConfigApplicationContext();
+    childContext.setParent(parentContext);
+
+    initializer.initialize(childContext);
+    childContext.refresh();
+
+    // Child should not have the bean locally (parent still has it)
+    assertThat(childContext.containsLocalBean("contextDiagnostic")).isFalse();
+    assertThat(parentContext.containsBean("contextDiagnostic")).isTrue();
+
+    parentContext.close();
+    childContext.close();
+  }
+
+  @Test
+  void shouldNotRegisterBeanTwiceOnMultipleRefresh() {
+    var context = new AnnotationConfigApplicationContext();
+    var initializer = new ContextDiagnosticApplicationInitializer();
+
+    initializer.initialize(context);
+
+    context.refresh();
+
+    // Simulate additional refresh events
+    context.publishEvent(new ContextRefreshedEvent(context));
+    context.publishEvent(new ContextRefreshedEvent(context));
+
+    // Should still have only one bean
+    assertThat(context.getBeansOfType(ContextDiagnostic.class)).hasSize(1);
+
+    context.close();
+  }
+
+  @Test
+  void shouldHaveCorrectEqualsAndHashCode() {
+    var initializer1 = new ContextDiagnosticApplicationInitializer();
+    var initializer2 = new ContextDiagnosticApplicationInitializer();
+
+    assertThat(initializer1).isEqualTo(initializer2);
+    assertThat(initializer1.hashCode()).isEqualTo(initializer2.hashCode());
+  }
+
+  @Test
+  void shouldNotThrowExceptionWithHierarchicalContexts() {
+    // This test verifies the fix doesn't break with real hierarchical contexts
+    try (var parentContext = new AnnotationConfigApplicationContext();
+        var childContext = new AnnotationConfigApplicationContext()) {
+      childContext.setParent(parentContext);
+
+      var initializer = new ContextDiagnosticApplicationInitializer();
+      initializer.initialize(parentContext);
+      initializer.initialize(childContext);
+
+      parentContext.refresh();
+      childContext.refresh();
+
+      assertThat(parentContext.isActive()).isTrue();
+      assertThat(childContext.isActive()).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
This pull request fixes the issue which caused the `contextDiagnostic` bean to be registered twice if more than one ContextRefreshedEvent was handled in `ContextDiagnosticApplicationInitializer`.

This fix changes the registration to only react to the main (parent) application context.