### PR TITLE
fix(report): compare differences in both context direction

### DIFF
--- a/src/main/resources/static/js/report.js
+++ b/src/main/resources/static/js/report.js
@@ -736,13 +736,19 @@ class ContextComparator {
 
   formatDetailedValue(attributeName, currentValues, comparisonValues) {
 
-    if (currentValues.length === 0 || (currentValues.length === 1 && !currentValues[0])) {
-      const noValuesHtml= `<div style="color: #6c757d; font-style: italic; text-align: center; padding: 20px;">No values configured</div>`;
+    const isEmptyA = currentValues.length === 0 || (currentValues.length === 1 && !currentValues[0]);
+    const isEmptyB = comparisonValues.length === 0 || (comparisonValues.length === 1 && !comparisonValues[0]);
+
+    if (isEmptyA && isEmptyB) {
+      const noValuesHtml = `<div style="color: #6c757d; font-style: italic; text-align: center; padding: 20px;">No values configured</div>`;
       return { leftHtml: noValuesHtml, rightHtml: noValuesHtml };
     }
 
     // Use diff.js to get the differences
-    const diff = Diff.diffArrays(currentValues, comparisonValues);
+    // Normalise falsy single-element arrays so the diff library receives clean inputs
+    const effectiveCurrentValues = isEmptyA ? [] : currentValues;
+    const effectiveComparisonValues = isEmptyB ? [] : comparisonValues;
+    const diff = Diff.diffArrays(effectiveCurrentValues, effectiveComparisonValues);
 
     // Create main container
     let leftHtml = `<div class="attribute-name">${attributeName}</div><div class="diff-container">`;


### PR DESCRIPTION
The formatDetailedValue() early-return guard was checking only the left side (Context A) for emptiness and returning "No values configured" for both sides. This caused the Detailed Comparison panel to display "No values configured" on both sides even when Context B had profiles.

Fix by checking both sides independently: only short-circuit when both are empty, and normalise single-falsy-element arrays to [] before passing them to Diff.diffArrays so the library produces the correct diff.