### PR TITLE
Improve Gradle quick start in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Add the dependency to your project:
 Add the dependency to your project:
 
 ```groovy
-testImplementation('digital.pragmatech.testing:spring-test-profiler:0.1.0')
+testRuntimeOnly("digital.pragmatech.testing:spring-test-profiler:0.1.0")
 ```
 
 


### PR DESCRIPTION
The previous version added the profiler as a `testImplementation` which unnecessarily allowed your test classes to see the profiler classes. This changes to `testRuntimeOnly` which allows the profiler to work but without enabling accidentally importing anything in your tests.