### PR TITLE
docs: add GitHub wiki sourced from docs/wiki with auto-sync workflow

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -1,0 +1,23 @@
+name: Publish Wiki
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/wiki/**
+      - .github/workflows/publish-wiki.yml
+
+permissions:
+  contents: write
+
+jobs:
+  publish-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Andrew-Chen-Wang/github-wiki-action@v5
+        with:
+          path: docs/wiki
+          # init force-pushes a fresh history: docs/wiki in the repo is the
+          # single source of truth, edits made via the wiki UI are discarded
+          strategy: init

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Fast build times = fast feedback and accelerated feature delivery!
 
 Find [more information](https://pragmatech.digital/products/spring-test-profiler/) about the profiler on our website.
 
+## Documentation
+
+The full documentation lives in the [GitHub wiki](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki) - this README only covers the quick start. Key pages:
+
+- [Getting Started](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Getting-Started)
+- [Understanding the Report](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Understanding-the-Report)
+- [Spring Context Caching](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Spring-Context-Caching)
+- [Configuration Reference](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Configuration-Reference)
+- [Advanced Usage](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Advanced-Usage)
+- [New Features](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/New-Features)
+
 ## How Context Caching Works
 
 Spring caches ApplicationContexts across tests: it X-rays each test's configuration, merges all customization points into a `MergedContextConfiguration`, and uses its hashCode as the cache key.
@@ -22,6 +33,7 @@ Same key means instant reuse - one tiny difference means a slow, brand-new conte
 
 ![Animation explaining Spring test context caching: Spring scans the test configuration, builds a cache key from the MergedContextConfiguration hashCode, and reuses matching ApplicationContexts](docs/context-caching-animation.gif)
 
+For a detailed explanation of the caching mechanics, see [Spring Context Caching](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Spring-Context-Caching) in the wiki.
 
 ## Features
 
@@ -59,12 +71,7 @@ This profiler works with Java 17+ and is compatible with:
 > [!WARNING]
 > This project is highly work-in-progress and should be considered a prototype to gather feedback and ideas for future development.
 
-What's currently not working or missing:
-
-- Support for parallel test execution
-- Fully-fledged visualization of the contexts on a timeline
-- For each Gradle test task, a separate HTML report is generated
-- For Surefire and Failsafe, a separate HTML report is generated
+The main current limitations are missing support for parallel test execution and separate reports per Gradle test task and per Surefire/Failsafe run. See [Troubleshooting and Limitations](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Troubleshooting-and-Limitations) in the wiki for the full list.
 
 ## Usage
 
@@ -142,93 +149,11 @@ After test execution, find the HTML report at:
 - Maven: `target/spring-test-profiler/latest.html`
 - Gradle: `build/spring-test-profiler/latest.html`
 
-Next to the HTML report, a flat JSON summary is written for machine consumption (CI checks,
-dashboards, trend tracking):
+Next to the HTML report, a flat JSON summary (`results.json`) is written for machine consumption - use it to track metrics like `contextsCreated` in CI and fail the build when your context count regresses. See [JSON Summary and CI Integration](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Advanced-Usage#json-summary-report) in the wiki for the metrics and ready-to-use CI snippets.
 
-- Maven: `target/spring-test-profiler/results.json` (latest run) plus a timestamped
-  `test-profiler-report-<timestamp>.json` per run
-- Gradle: `build/spring-test-profiler/results.json` plus the timestamped file per run
+### 5. Go Further
 
-The JSON contains a single flat object with metrics like `contextsCreated`, `totalDurationMs`,
-`contextCacheHitRatio`, and `totalContextCreationTimeMs`, so it can be consumed with simple
-tooling:
-
-```bash
-jq '.contextsCreated' target/spring-test-profiler/results.json
-```
-
-#### Guard Your Context Count in CI
-
-Once you have optimized your test suite, you can pin the expected number of created contexts and
-fail the build when it regresses (for example when someone introduces a new `@DirtiesContext` or
-an accidental context configuration difference). Run this after your test suite, e.g. as a CI
-step:
-
-```bash
-expectedContexts=3
-actualContexts=$(jq -r '.contextsCreated' target/spring-test-profiler/results.json)
-
-if [ "$actualContexts" != "$expectedContexts" ]; then
-  echo "Expected $expectedContexts Spring contexts but $actualContexts were created"
-  exit 1
-fi
-```
-
-Other metrics work the same way, for example alerting when context creation time exceeds a budget:
-
-```bash
-totalContextCreationTimeMs=$(jq -r '.totalContextCreationTimeMs' target/spring-test-profiler/results.json)
-
-if [ "$totalContextCreationTimeMs" -gt 60000 ]; then
-  echo "Context creation took ${totalContextCreationTimeMs}ms, exceeding the 60s budget"
-  exit 1
-fi
-```
-
-This repository uses the same approach for its demo projects: each demo pins its expected context
-count in a `context-info.json` file, and the CI pipeline verifies the generated `results.json`
-against it with [`.github/scripts/verify-profiler-json.sh`](.github/scripts/verify-profiler-json.sh).
-
-### 5. Add Custom Context Customizer Descriptions
-
-Spring Test Profiler can show richer context customizer details when your project exposes a
-`ContextCustomizerExtension` bean. This is useful when a customizer class is the same across test
-contexts, but its internal configuration is different. A common example is a WireMock
-`WireMockContextCustomizer`: two tests can both use the same customizer class, while each test
-configures different mock names, ports, files, or properties.
-
-Create a Spring bean in your test application context, for example with `@Component` or a test
-`@Bean` method:
-
-```java
-package com.example.testing;
-
-import digital.pragmatech.testing.extensions.ContextCustomizerExtension;
-import org.springframework.stereotype.Component;
-
-@Component
-class ExampleContextCustomizerExtension implements ContextCustomizerExtension {
-
-  @Override
-  public boolean supports(Object contextCustomizer) {
-    // Return true only for the customizer type this extension knows how to describe.
-    return contextCustomizer.getClass().getName().contains("ExampleContextCustomizer");
-  }
-
-  @Override
-  public String describe(Object contextCustomizer) {
-    // Return a stable, human-readable summary of the fields that make contexts differ.
-    return contextCustomizer.getClass().getSimpleName() + "[configuration=custom]";
-  }
-}
-```
-
-The `supports(...)` method should be narrow: check the exact customizer class or a known interface.
-The `describe(...)` method should include only deterministic configuration values that help explain why Spring created
-a separate context. Avoid identity hashes, timestamps, random ports, or other values that change between runs unless
-they are the actual configuration you want to compare.
-
-If no extension supports a customizer, the report falls back to the customizer class simple name.
+For custom context customizer descriptions, CI integration with the JSON summary, custom report directories, and a walkthrough of every report section, head over to the [wiki](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki) - in particular [Advanced Usage](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Advanced-Usage) and [Understanding the Report](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Understanding-the-Report).
 
 ## Demo Report
 
@@ -236,34 +161,8 @@ Access a demo Spring Test Profiler report [here](https://pragmatech.digital/prod
 
 ## Bug Reports
 
-Found a bug? Please help us improve by reporting it:
-
-1. **Search existing issues** at https://github.com/PragmaTech-GmbH/spring-test-profiler/issues
-2. **Create a new issue** with:
-   - Clear description of the problem
-   - Steps to reproduce
-   - Expected vs actual behavior
-   - Java/Spring/JUnit versions
-   - Relevant log output or screenshots
+Found a bug? Please report it via the [issue tracker](https://github.com/PragmaTech-GmbH/spring-test-profiler/issues) - the wiki's [Troubleshooting and Limitations](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Troubleshooting-and-Limitations) page explains what a helpful report looks like.
 
 ## Contributing
 
-We welcome contributions! Here's how to get started:
-
-### Development Setup
-
-1. **Fork and clone** the repository
-2. **Activate pre-commit hooks** (this ensures compliant code formatting): `pre-commit install` ([pre-commit download](https://pre-commit.com/))
-3. **Build the project**:
-
-```bash
-./mvnw install
-```
-
-3. **Run tests**:
-
-```bash
-./mvnw test
-```
-
-4. Use conventional commit messages for your changes (e.g., `feat: add new feature`, `fix: resolve issue #123`)
+We welcome contributions! See the [Contributing](https://github.com/PragmaTech-GmbH/spring-test-profiler/wiki/Contributing) page in the wiki for the development setup and guidelines.

--- a/docs/wiki/Advanced-Usage.md
+++ b/docs/wiki/Advanced-Usage.md
@@ -1,0 +1,65 @@
+# Advanced Usage
+
+## Custom Context Customizer Descriptions
+
+Spring Test Profiler can show richer context customizer details when your project exposes a `ContextCustomizerExtension` bean. This is useful when a customizer class is the same across test contexts, but its internal configuration is different. A common example is a WireMock `WireMockContextCustomizer`: two tests can both use the same customizer class, while each test configures different mock names, ports, files, or properties.
+
+Without an extension, the report falls back to the customizer's simple class name - which makes two differing contexts look identical in the diff view.
+
+### Implementing an Extension
+
+Create a Spring bean in your test application context, for example with `@Component` or a test `@Bean` method:
+
+```java
+package com.example.testing;
+
+import digital.pragmatech.testing.extensions.ContextCustomizerExtension;
+import org.springframework.stereotype.Component;
+
+@Component
+class ExampleContextCustomizerExtension implements ContextCustomizerExtension {
+
+  @Override
+  public boolean supports(Object contextCustomizer) {
+    // Return true only for the customizer type this extension knows how to describe.
+    return contextCustomizer.getClass().getName().contains("ExampleContextCustomizer");
+  }
+
+  @Override
+  public String describe(Object contextCustomizer) {
+    // Return a stable, human-readable summary of the fields that make contexts differ.
+    return contextCustomizer.getClass().getSimpleName() + "[configuration=custom]";
+  }
+}
+```
+
+### Guidelines
+
+- The `supports(...)` method should be narrow: check the exact customizer class or a known interface.
+- The `describe(...)` method should include only deterministic configuration values that help explain why Spring created a separate context. Avoid identity hashes, timestamps, random ports, or other values that change between runs unless they are the actual configuration you want to compare.
+- If no extension supports a customizer, the report falls back to the customizer class simple name.
+
+## Custom Report Directory
+
+By default, reports land in `target/spring-test-profiler/` (Maven) or `build/spring-test-profiler/` (Gradle). Override the location with the `pragmatech.spring.test.insight.report.dir` system property:
+
+```bash
+./mvnw verify -Dpragmatech.spring.test.insight.report.dir=/tmp/profiler-reports
+```
+
+See the [Configuration Reference](Configuration-Reference.md) for details.
+
+## JSON Report (Beta)
+
+Next to the HTML report, the profiler can emit a structured JSON report for programmatic consumption - for example to track cache hit rates across CI builds or feed dashboards.
+
+Enable it with:
+
+```bash
+./mvnw verify -Dspring.test.insight.json.beta=true
+```
+
+The JSON file is written to the same report directory as the HTML report.
+
+> [!NOTE]
+> The JSON format is in beta: its structure may change between releases without notice. Pin the profiler version if you build tooling on top of it, and share feedback via the [issue tracker](https://github.com/PragmaTech-GmbH/spring-test-profiler/issues).

--- a/docs/wiki/Advanced-Usage.md
+++ b/docs/wiki/Advanced-Usage.md
@@ -49,17 +49,62 @@ By default, reports land in `target/spring-test-profiler/` (Maven) or `build/spr
 
 See the [Configuration Reference](Configuration-Reference.md) for details.
 
-## JSON Report (Beta)
+## JSON Summary Report
 
-Next to the HTML report, the profiler can emit a structured JSON report for programmatic consumption - for example to track cache hit rates across CI builds or feed dashboards.
+Next to the HTML report, a flat JSON summary is written for machine consumption (CI checks, dashboards, trend tracking):
 
-Enable it with:
+- Maven: `target/spring-test-profiler/results.json` (latest run) plus a timestamped `test-profiler-report-<timestamp>.json` per run
+- Gradle: `build/spring-test-profiler/results.json` plus the timestamped file per run
+
+The JSON contains a single flat object, so it can be consumed with simple tooling:
 
 ```bash
-./mvnw verify -Dspring.test.insight.json.beta=true
+jq '.contextsCreated' target/spring-test-profiler/results.json
 ```
 
-The JSON file is written to the same report directory as the HTML report.
+### Available Metrics
 
-> [!NOTE]
-> The JSON format is in beta: its structure may change between releases without notice. Pin the profiler version if you build tooling on top of it, and share feedback via the [issue tracker](https://github.com/PragmaTech-GmbH/spring-test-profiler/issues).
+All duration values are in milliseconds. The `schemaVersion` field allows the format to evolve without breaking consumers (currently `1`). Test-level counts (classes, methods, pass/fail) are intentionally not included - build tools like Surefire, Failsafe, and Gradle already report them.
+
+| Field | Description |
+|---|---|
+| `schemaVersion` | Version of the JSON format |
+| `profilerVersion` | Spring Test Profiler version that produced the file |
+| `generatedAt` | Timestamp of report generation |
+| `buildTool` | Detected build tool (Maven/Gradle) |
+| `totalDurationMs` | Total duration of the profiled test run |
+| `contextsCreated` | Number of application contexts created |
+| `contextCacheHits` / `contextCacheMisses` | Context cache hit and miss counts |
+| `contextCacheHitRatio` | Cache hit ratio |
+| `springContextCacheSize` / `springContextCacheMaxSize` | Spring's internal cache usage and limit |
+| `totalContextCreationTimeMs` | Total time spent creating contexts |
+| `wastedContextTimeMs` | Time spent creating contexts that could have been reused |
+| `potentialTimeSavingsMs` / `potentialTimeSavingsPercent` | Estimated savings from full context reuse |
+| `availableProcessors` | Processor count of the machine running the tests |
+
+### Guard Your Context Count in CI
+
+Once you have optimized your test suite, you can pin the expected number of created contexts and fail the build when it regresses (for example when someone introduces a new `@DirtiesContext` or an accidental context configuration difference). Run this after your test suite, e.g. as a CI step:
+
+```bash
+expectedContexts=3
+actualContexts=$(jq -r '.contextsCreated' target/spring-test-profiler/results.json)
+
+if [ "$actualContexts" != "$expectedContexts" ]; then
+  echo "Expected $expectedContexts Spring contexts but $actualContexts were created"
+  exit 1
+fi
+```
+
+Other metrics work the same way, for example alerting when context creation time exceeds a budget:
+
+```bash
+totalContextCreationTimeMs=$(jq -r '.totalContextCreationTimeMs' target/spring-test-profiler/results.json)
+
+if [ "$totalContextCreationTimeMs" -gt 60000 ]; then
+  echo "Context creation took ${totalContextCreationTimeMs}ms, exceeding the 60s budget"
+  exit 1
+fi
+```
+
+The profiler repository uses the same approach for its own demo projects: each demo pins its expected context count in a `context-info.json` file, and the CI pipeline verifies the generated `results.json` against it with [`.github/scripts/verify-profiler-json.sh`](https://github.com/PragmaTech-GmbH/spring-test-profiler/blob/main/.github/scripts/verify-profiler-json.sh) - see [Demo Projects](Demo-Projects.md).

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -9,23 +9,12 @@ Pass these as JVM system properties to your test execution, for example via `-D`
 | Property | Default | Description |
 |---|---|---|
 | `pragmatech.spring.test.insight.report.dir` | _(unset)_ | Overrides the report output directory. When unset, the directory is derived from the detected build tool (see below). |
-| `spring.test.insight.json.beta` | `false` | When `true`, additionally generates a JSON report next to the HTML report. This feature is in beta - see [Advanced Usage](Advanced-Usage.md#json-report-beta). |
 
-### Examples
+### Example
 
 ```bash
 # Maven: custom report directory
 ./mvnw verify -Dpragmatech.spring.test.insight.report.dir=/tmp/profiler-reports
-
-# Maven: enable the beta JSON report
-./mvnw verify -Dspring.test.insight.json.beta=true
-```
-
-```groovy
-// Gradle: build.gradle
-test {
-  systemProperty 'spring.test.insight.json.beta', 'true'
-}
 ```
 
 ## Report Output
@@ -46,10 +35,12 @@ The build tool is detected automatically at runtime.
 
 Each test run produces:
 
-- `test-profiler-report-<timestamp>.html` - the timestamped report for this run
-- `latest.html` - always points to the most recent report, so you can bookmark one stable path
+- `test-profiler-report-<timestamp>.html` - the timestamped HTML report for this run
+- `latest.html` - always holds the most recent report, so you can bookmark one stable path
+- `test-profiler-report-<timestamp>.json` - the timestamped flat JSON summary for this run
+- `results.json` - always holds the most recent JSON summary, ideal for CI tooling
 
-Reports are self-contained HTML files with all CSS and JavaScript inlined - no external assets needed to view or archive them.
+Reports are self-contained HTML files with all CSS and JavaScript inlined - no external assets needed to view or archive them. The JSON summary and its metrics are documented in [Advanced Usage](Advanced-Usage.md#json-summary-report).
 
 ## Activation
 

--- a/docs/wiki/Configuration-Reference.md
+++ b/docs/wiki/Configuration-Reference.md
@@ -1,0 +1,56 @@
+# Configuration Reference
+
+The Spring Test Profiler works with zero configuration. The options below let you adjust report output when the defaults do not fit your setup.
+
+## System Properties
+
+Pass these as JVM system properties to your test execution, for example via `-D` on the command line, the Surefire/Failsafe `argLine`, or the Gradle `test` task's `systemProperty`.
+
+| Property | Default | Description |
+|---|---|---|
+| `pragmatech.spring.test.insight.report.dir` | _(unset)_ | Overrides the report output directory. When unset, the directory is derived from the detected build tool (see below). |
+| `spring.test.insight.json.beta` | `false` | When `true`, additionally generates a JSON report next to the HTML report. This feature is in beta - see [Advanced Usage](Advanced-Usage.md#json-report-beta). |
+
+### Examples
+
+```bash
+# Maven: custom report directory
+./mvnw verify -Dpragmatech.spring.test.insight.report.dir=/tmp/profiler-reports
+
+# Maven: enable the beta JSON report
+./mvnw verify -Dspring.test.insight.json.beta=true
+```
+
+```groovy
+// Gradle: build.gradle
+test {
+  systemProperty 'spring.test.insight.json.beta', 'true'
+}
+```
+
+## Report Output
+
+### Location
+
+Unless overridden via `pragmatech.spring.test.insight.report.dir`, reports are written to a `spring-test-profiler` directory inside your build output folder:
+
+| Build Tool | Report Directory |
+|---|---|
+| Maven | `target/spring-test-profiler/` |
+| Gradle | `build/spring-test-profiler/` |
+| Unknown | Falls back to detecting an existing `target/` or `build/` directory |
+
+The build tool is detected automatically at runtime.
+
+### File Naming
+
+Each test run produces:
+
+- `test-profiler-report-<timestamp>.html` - the timestamped report for this run
+- `latest.html` - always points to the most recent report, so you can bookmark one stable path
+
+Reports are self-contained HTML files with all CSS and JavaScript inlined - no external assets needed to view or archive them.
+
+## Activation
+
+Activation is not configured via properties but via Spring's `spring.factories` service loader mechanism or annotations - see [Getting Started](Getting-Started.md#2-activate-the-profiler).

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -1,0 +1,46 @@
+# Contributing
+
+We welcome contributions! This page covers everything you need to get a local development environment running.
+
+## Development Setup
+
+1. **Fork and clone** the [repository](https://github.com/PragmaTech-GmbH/spring-test-profiler)
+2. **Activate pre-commit hooks** (this ensures compliant code formatting): `pre-commit install` ([pre-commit download](https://pre-commit.com/))
+3. **Build the project**:
+
+```bash
+./mvnw install
+```
+
+4. **Run the tests**:
+
+```bash
+./mvnw test
+```
+
+## Testing Your Changes Against the Demos
+
+The [demo projects](Demo-Projects.md) are the quickest way to see your change in a realistic setup:
+
+```bash
+./mvnw clean install
+cd demo/spring-boot-3.5-maven
+mvn clean verify
+# Inspect target/spring-test-profiler/latest.html
+```
+
+## Commit Messages
+
+Use conventional commit messages for your changes, for example:
+
+- `feat: add new feature`
+- `fix: resolve issue #123`
+- `docs: clarify Gradle setup`
+
+## Documentation
+
+The GitHub wiki is generated from the [`docs/wiki/`](https://github.com/PragmaTech-GmbH/spring-test-profiler/tree/main/docs/wiki) directory in the repository - it is the single source of truth for documentation. To improve the docs, edit the files there and open a pull request. Do **not** edit wiki pages through the GitHub wiki UI: changes made there are overwritten on the next sync.
+
+## Reporting Bugs
+
+See [Troubleshooting and Limitations](Troubleshooting-and-Limitations.md#reporting-bugs).

--- a/docs/wiki/Demo-Projects.md
+++ b/docs/wiki/Demo-Projects.md
@@ -1,0 +1,38 @@
+# Demo Projects
+
+The [`demo/`](https://github.com/PragmaTech-GmbH/spring-test-profiler/tree/main/demo) directory contains standalone example projects that show the profiler in realistic setups. Each demo is a complete Spring Boot application with tests - use them as a reference for integrating the profiler into your own build.
+
+## Available Demos
+
+| Demo | Spring Boot | Build Tool | Demonstrates | Verified in CI |
+|---|---|---|---|---|
+| `spring-boot-2.7-maven` | 2.7 (Spring Framework 5) | Maven | Backward compatibility with Spring Boot 2 | ✅ |
+| `spring-boot-3.4-maven` | 3.4 | Maven | Standard Spring Boot 3.4 setup | ✅ |
+| `spring-boot-3.5-maven` | 3.5 | Maven | Baseline Spring Boot 3.5 setup | ✅ |
+| `spring-boot-3.5-gradle` | 3.5 | Gradle | Gradle integration, report under `build/` | ✅ |
+| `spring-boot-3.5-maven-multimodule` | 3.5 | Maven | Profiler in a multi-module build | - |
+| `spring-boot-3.5-maven-junit-parallel` | 3.5 | Maven | JUnit parallel execution (not yet supported, see [limitations](Troubleshooting-and-Limitations.md)) | - |
+| `spring-boot-3.5-maven-failsafe-parallel` | 3.5 | Maven | Failsafe parallel execution (not yet supported, see [limitations](Troubleshooting-and-Limitations.md)) | - |
+| `spring-boot-4.0-maven` | 4.0 (Spring Framework 7) | Maven | Forward compatibility with Spring Boot 4 | ✅ |
+
+## Running a Demo
+
+The demos consume the profiler from your local Maven repository, so install it first from the repository root:
+
+```bash
+./mvnw clean install
+```
+
+Then run any demo:
+
+```bash
+# Maven demo
+cd demo/spring-boot-3.5-maven
+mvn clean verify
+# Report: target/spring-test-profiler/latest.html
+
+# Gradle demo
+cd demo/spring-boot-3.5-gradle
+./gradlew build
+# Report: build/spring-test-profiler/latest.html
+```

--- a/docs/wiki/Demo-Projects.md
+++ b/docs/wiki/Demo-Projects.md
@@ -36,3 +36,7 @@ cd demo/spring-boot-3.5-gradle
 ./gradlew build
 # Report: build/spring-test-profiler/latest.html
 ```
+
+## Pinned Context Counts
+
+Each CI-verified demo pins its expected number of created Spring contexts in a `context-info.json` file. The CI pipeline compares it against the `results.json` written by the profiler using [`.github/scripts/verify-profiler-json.sh`](https://github.com/PragmaTech-GmbH/spring-test-profiler/blob/main/.github/scripts/verify-profiler-json.sh), so a regression in context caching fails the build. You can use the same pattern in your own project - see [Advanced Usage](Advanced-Usage.md#guard-your-context-count-in-ci).

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -18,7 +18,7 @@ The profiler is only needed at test runtime, so add it with test scope.
 <dependency>
   <groupId>digital.pragmatech.testing</groupId>
   <artifactId>spring-test-profiler</artifactId>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -26,7 +26,7 @@ The profiler is only needed at test runtime, so add it with test scope.
 ### Gradle
 
 ```groovy
-testRuntimeOnly("digital.pragmatech.testing:spring-test-profiler:0.2.1")
+testRuntimeOnly("digital.pragmatech.testing:spring-test-profiler:0.2.2")
 ```
 
 ## 2. Activate the Profiler

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,87 @@
+# Getting Started
+
+This guide takes you from zero to your first Spring Test Profiler report.
+
+## Prerequisites
+
+- Java 17+
+- Spring Framework 5, 6, or 7 (Spring Boot 2, 3, or 4)
+- Maven or Gradle
+
+## 1. Add the Dependency
+
+The profiler is only needed at test runtime, so add it with test scope.
+
+### Maven
+
+```xml
+<dependency>
+  <groupId>digital.pragmatech.testing</groupId>
+  <artifactId>spring-test-profiler</artifactId>
+  <version>0.1.2</version>
+  <scope>test</scope>
+</dependency>
+```
+
+### Gradle
+
+```groovy
+testRuntimeOnly("digital.pragmatech.testing:spring-test-profiler:0.1.2")
+```
+
+## 2. Activate the Profiler
+
+Pick **either one** of the following methods.
+
+### Automatically for All Your Tests (Recommended)
+
+Add a file named `META-INF/spring.factories` to your test resources directory (for example `src/test/resources/META-INF/spring.factories`) with the following content:
+
+```text
+org.springframework.test.context.TestExecutionListener=\
+digital.pragmatech.testing.SpringTestProfilerListener
+org.springframework.context.ApplicationContextInitializer=\
+digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer
+```
+
+Spring's service loader mechanism picks this up automatically - no code changes required.
+
+### Manually for Specific Tests
+
+Add the `@TestExecutionListeners` and `@ContextConfiguration` annotations to your test classes:
+
+```java
+@TestExecutionListeners(
+  value = {SpringTestProfilerListener.class},
+  mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS
+)
+@ContextConfiguration(initializers = ContextDiagnosticApplicationInitializer.class)
+```
+
+This needs to be done for each test class where you want to use the profiler. Preferably, place these annotations on a central abstract integration test class, or use the automatic activation method above.
+
+## 3. Run Your Tests
+
+```bash
+# Maven
+./mvnw verify
+
+# Gradle
+./gradlew build
+```
+
+## 4. Open the Report
+
+After test execution, find the HTML report at:
+
+- Maven: `target/spring-test-profiler/latest.html`
+- Gradle: `build/spring-test-profiler/latest.html`
+
+The report is fully self-contained (CSS and JavaScript are inlined), so you can open it directly in a browser, archive it as a CI artifact, or share it with your team.
+
+## Next Steps
+
+- Learn what each section of the report means: [Understanding the Report](Understanding-the-Report.md)
+- Understand the underlying mechanics: [Spring Context Caching](Spring-Context-Caching.md)
+- Tune output locations and formats: [Configuration Reference](Configuration-Reference.md)
+- Explore working examples: [Demo Projects](Demo-Projects.md)

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -18,7 +18,7 @@ The profiler is only needed at test runtime, so add it with test scope.
 <dependency>
   <groupId>digital.pragmatech.testing</groupId>
   <artifactId>spring-test-profiler</artifactId>
-  <version>0.1.2</version>
+  <version>0.2.1</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -26,7 +26,7 @@ The profiler is only needed at test runtime, so add it with test scope.
 ### Gradle
 
 ```groovy
-testRuntimeOnly("digital.pragmatech.testing:spring-test-profiler:0.1.2")
+testRuntimeOnly("digital.pragmatech.testing:spring-test-profiler:0.2.1")
 ```
 
 ## 2. Activate the Profiler
@@ -78,6 +78,8 @@ After test execution, find the HTML report at:
 - Gradle: `build/spring-test-profiler/latest.html`
 
 The report is fully self-contained (CSS and JavaScript are inlined), so you can open it directly in a browser, archive it as a CI artifact, or share it with your team.
+
+Next to the HTML report, a flat JSON summary (`results.json`) is written for machine consumption - see [Advanced Usage](Advanced-Usage.md#json-summary-report) for the available metrics and how to guard your context count in CI.
 
 ## Next Steps
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,40 @@
+# Spring Test Profiler
+
+Welcome to the Spring Test Profiler documentation. This wiki is the single source of truth for everything beyond the [README quick start](https://github.com/PragmaTech-GmbH/spring-test-profiler#usage).
+
+Spring's `TestContext` context caching is one of the most unknown hidden gems of testing with Spring Boot - it can cut your build times in half, and often even more. The Spring Test Profiler visualizes how your test suite uses (or misses) this cache and points you to concrete optimization opportunities.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/PragmaTech-GmbH/spring-test-profiler/main/docs/report-top.png" alt="Spring Test Profiler Report" />
+</p>
+
+## Where to Go
+
+| Page | What You Will Find |
+|---|---|
+| [Getting Started](Getting-Started.md) | Installation, activation, and your first report |
+| [Understanding the Report](Understanding-the-Report.md) | A walkthrough of every report section |
+| [Spring Context Caching](Spring-Context-Caching.md) | Background on how the `TestContext` cache works and why contexts differ |
+| [Configuration Reference](Configuration-Reference.md) | All system properties and report output locations |
+| [Advanced Usage](Advanced-Usage.md) | Context customizer extensions, custom report directories, JSON reports |
+| [New Features](New-Features.md) | Curated highlights of recent releases |
+| [Demo Projects](Demo-Projects.md) | Ready-to-run example projects for every supported setup |
+| [Troubleshooting and Limitations](Troubleshooting-and-Limitations.md) | Known limitations, common issues, and how to report bugs |
+| [Contributing](Contributing.md) | Development setup and contribution guidelines |
+
+## Requirements at a Glance
+
+The profiler works with Java 17+ and is compatible with:
+
+- Spring Framework 5 (Spring Boot 2)
+- Spring Framework 6 (Spring Boot 3)
+- Spring Framework 7 (Spring Boot 4)
+
+It supports both Maven (Surefire/Failsafe) and Gradle test tasks.
+
+## Links
+
+- [Product page and demo report](https://pragmatech.digital/products/spring-test-profiler/)
+- [GitHub repository](https://github.com/PragmaTech-GmbH/spring-test-profiler)
+- [GitHub releases](https://github.com/PragmaTech-GmbH/spring-test-profiler/releases)
+- [Issue tracker](https://github.com/PragmaTech-GmbH/spring-test-profiler/issues)

--- a/docs/wiki/New-Features.md
+++ b/docs/wiki/New-Features.md
@@ -1,0 +1,62 @@
+# New Features
+
+Curated highlights of what landed in recent releases. For the complete changelog, see the [GitHub releases](https://github.com/PragmaTech-GmbH/spring-test-profiler/releases).
+
+## 0.1.2
+
+### Self-Contained Reports ([#46](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/46))
+
+All CSS and JavaScript is now inlined into the HTML report. A report is a single file with no external assets, so it renders correctly when archived as a CI artifact, attached to an issue, or sent to a colleague.
+
+## 0.1.1
+
+### Context Customizer Extensions in Reports ([#44](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/44))
+
+The report can now display meaningful descriptions for context customizers whose class name alone does not explain why two contexts differ (for example WireMock customizers). Provide a `ContextCustomizerExtension` bean and the diff view shows your custom description instead of just the class name.
+
+```java
+@Component
+class WireMockCustomizerExtension implements ContextCustomizerExtension {
+  @Override
+  public boolean supports(Object contextCustomizer) {
+    return contextCustomizer.getClass().getName().contains("WireMockContextCustomizer");
+  }
+
+  @Override
+  public String describe(Object contextCustomizer) {
+    return "WireMock[...stable configuration summary...]";
+  }
+}
+```
+
+See the full guide in [Advanced Usage](Advanced-Usage.md#custom-context-customizer-descriptions).
+
+## 0.1.0
+
+### Reworked Report Overview ([#42](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/42))
+
+The core tiles at the top of the report were adjusted to surface the most decision-relevant numbers first.
+
+## 0.0.18
+
+### Spring Framework 5 / Spring Boot 2 Compatibility ([#40](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/40))
+
+The profiler now also runs on Spring Framework 5 (Spring Boot 2.x), extending support across three major Spring generations.
+
+### Sortable Context Cache Entries ([#39](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/39))
+
+The Context Cache Entries section gained sorting controls, so you can order contexts by load time and find the most expensive ones first.
+
+### Annotation-Based Context Filtering ([#36](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/36))
+
+Filter contexts in the report by the test annotations that produced them (for example `@SpringBootTest` vs `@WebMvcTest`).
+
+## 0.0.16
+
+### Spring Boot 4 Support ([#33](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/33))
+
+The profiler supports Spring Framework 7 / Spring Boot 4, alongside a simplified report.
+
+---
+
+Older changes are listed on the [releases page](https://github.com/PragmaTech-GmbH/spring-test-profiler/releases).

--- a/docs/wiki/New-Features.md
+++ b/docs/wiki/New-Features.md
@@ -2,6 +2,30 @@
 
 Curated highlights of what landed in recent releases. For the complete changelog, see the [GitHub releases](https://github.com/PragmaTech-GmbH/spring-test-profiler/releases).
 
+## 0.2.1
+
+### Flat JSON Summary Report with CI Verification ([#53](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/53))
+
+Every run now writes a machine-readable `results.json` next to the HTML report - a single flat object with metrics like `contextsCreated`, `contextCacheHitRatio`, and `totalContextCreationTimeMs`. Pin your expected context count in CI and fail the build when it regresses:
+
+```bash
+jq '.contextsCreated' target/spring-test-profiler/results.json
+```
+
+This replaces the previous beta JSON report and its `spring.test.insight.json.beta` flag. See [Advanced Usage](Advanced-Usage.md#json-summary-report) for the full metric reference and ready-to-use CI snippets.
+
+### Context Caching Timeline Visualization ([#34](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/34), [#50](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/50))
+
+The report now renders a first visualization of the context cache over time, including tracking of context removals from the cache.
+
+### Context Caching Explained with an Animation ([#49](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/49))
+
+The report's theory section explains Spring's context caching mechanism with an animation: configuration scan, `MergedContextConfiguration` cache key, hit or miss. The same animation is embedded in [Spring Context Caching](Spring-Context-Caching.md).
+
+### Total Contexts Created Tile ([#54](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/54))
+
+The summary section gained a "Total Contexts Created" tile, surfacing the most important optimization number at first glance.
+
 ## 0.1.2
 
 ### Self-Contained Reports ([#46](https://github.com/PragmaTech-GmbH/spring-test-profiler/pull/46))

--- a/docs/wiki/Spring-Context-Caching.md
+++ b/docs/wiki/Spring-Context-Caching.md
@@ -1,0 +1,49 @@
+# Spring Context Caching
+
+This page explains the Spring mechanism the profiler is built around. Understanding it makes the report much easier to act on.
+
+## How the TestContext Cache Works
+
+Starting a Spring application context is expensive - often several seconds per context for a real application. To avoid paying that cost for every test class, the Spring TestContext Framework caches application contexts **within one JVM test run** and reuses them across test classes.
+
+Whether a context can be reused is decided by the context's cache key, derived from the `MergedContextConfiguration` of a test class. Roughly, two test classes share a context only when **all** of the following match:
+
+- Context configuration classes and locations (`@ContextConfiguration`, `@SpringBootTest` classes)
+- Active profiles (`@ActiveProfiles`)
+- Property sources and inlined properties (`@TestPropertySource`, `properties` attributes)
+- Context initializers
+- Context customizers (added by annotations like `@MockBean`, `@DynamicPropertySource`, WireMock integrations, Testcontainers integrations, and so on)
+- Parent context, context loader, and web configuration
+
+If a single attribute differs, Spring creates and caches a **new** context.
+
+## Why Your Cache Hit Rate Is Low
+
+Common, often accidental, causes for contexts not being reused:
+
+- `@DirtiesContext` - marks the context as dirty and forces a fresh one afterwards
+- `@MockBean` / `@MockitoBean` on individual test classes - each distinct set of mocked beans creates a distinct context customizer, and therefore a distinct context
+- Different `@ActiveProfiles` or `@TestPropertySource` values across otherwise identical test classes
+- Different test slices (`@WebMvcTest`, `@DataJpaTest`, `@SpringBootTest`) - by design these produce different contexts, which is fine, but mixing arbitrary configurations within a slice multiplies contexts
+- Dynamic values in the configuration, such as random ports or per-test property values
+
+The report's [context configuration diff view](Understanding-the-Report.md#spring-context-configurations) shows exactly which attribute differs between two contexts.
+
+## The Cache Size Limit
+
+Spring's context cache holds **32 contexts by default** (configurable via the `spring.test.context.cache.maxSize` property). When the limit is exceeded, the least recently used context is closed and evicted. Test suites with many distinct configurations can silently thrash this cache: contexts get evicted and re-created, and Spring's built-in statistics no longer tell the full story.
+
+The Spring Test Profiler tracks context usage **independently** of Spring's internal cache, so its metrics stay complete even when your suite creates more contexts than the cache can hold.
+
+## What Good Looks Like
+
+- A handful of distinct contexts, deliberately chosen (for example: one full `@SpringBootTest` context, one `@WebMvcTest` slice, one `@DataJpaTest` slice)
+- A high cache hit rate - most test classes reuse an existing context
+- Context creation clustered at the start of the run rather than spread throughout
+
+To move your suite in this direction, follow the recommendations in the report's [optimization section](Understanding-the-Report.md#optimization-recommendations).
+
+## Further Reading
+
+- [Spring Framework reference: Context Caching](https://docs.spring.io/spring-framework/reference/testing/testcontext-framework/ctx-management/caching.html)
+- [Understanding the Report](Understanding-the-Report.md)

--- a/docs/wiki/Spring-Context-Caching.md
+++ b/docs/wiki/Spring-Context-Caching.md
@@ -6,7 +6,20 @@ This page explains the Spring mechanism the profiler is built around. Understand
 
 Starting a Spring application context is expensive - often several seconds per context for a real application. To avoid paying that cost for every test class, the Spring TestContext Framework caches application contexts **within one JVM test run** and reuses them across test classes.
 
-Whether a context can be reused is decided by the context's cache key, derived from the `MergedContextConfiguration` of a test class. Roughly, two test classes share a context only when **all** of the following match:
+The animation below (also shown in the report's theory section) illustrates the mechanism:
+
+![Animation explaining Spring test context caching: Spring scans the test configuration, builds a cache key from the MergedContextConfiguration hashCode, and reuses matching ApplicationContexts](https://raw.githubusercontent.com/PragmaTech-GmbH/spring-test-profiler/main/docs/context-caching-animation.gif)
+
+Step by step, this is what happens for every Spring test class:
+
+1. **Configuration scan** - before running a test class, Spring X-rays its complete test configuration: annotations like `@SpringBootTest`, `@ContextConfiguration`, `@ActiveProfiles`, `@TestPropertySource`, plus everything contributed indirectly, such as context customizers from `@MockBean` or Testcontainers/WireMock integrations.
+2. **Merge into one object** - all these customization points are merged into a single `MergedContextConfiguration` instance that fully describes the context this test class needs.
+3. **Cache key from hashCode** - the `hashCode` of that `MergedContextConfiguration` (backed by `equals`) acts as the cache key into the context cache.
+4. **Hit or miss** - if a context with the same key already exists in the cache, the test reuses it instantly (cache hit). If not, Spring starts a brand-new application context - often the slowest step of the whole test class - and stores it under the new key (cache miss).
+
+The crucial consequence: same key means instant reuse, while **one tiny difference** in any configuration attribute means a slow, brand-new context. There is no "close enough" - the key either matches exactly or it does not.
+
+Whether a context can be reused is therefore decided entirely by the attributes that flow into the `MergedContextConfiguration`. Roughly, two test classes share a context only when **all** of the following match:
 
 - Context configuration classes and locations (`@ContextConfiguration`, `@SpringBootTest` classes)
 - Active profiles (`@ActiveProfiles`)

--- a/docs/wiki/Troubleshooting-and-Limitations.md
+++ b/docs/wiki/Troubleshooting-and-Limitations.md
@@ -1,0 +1,44 @@
+# Troubleshooting and Limitations
+
+## Prototype Phase
+
+> [!WARNING]
+> This project is highly work-in-progress and should be considered a prototype to gather feedback and ideas for future development.
+
+## Known Limitations
+
+- **Parallel test execution is not yet supported.** Running tests in parallel (JUnit parallel execution or Surefire/Failsafe forking) can produce incomplete or inaccurate reports.
+- **The context timeline visualization is not fully fledged yet.** Expect gaps and rough edges in the timeline section of the report.
+- **Gradle: one report per test task.** Each Gradle test task generates its own HTML report instead of one combined report.
+- **Maven: separate reports for Surefire and Failsafe.** Unit tests (Surefire) and integration tests (Failsafe) each produce their own report.
+
+## Common Issues
+
+### No Report Is Generated
+
+1. Verify the dependency is on the **test** classpath (`<scope>test</scope>` for Maven, `testRuntimeOnly` for Gradle).
+2. Verify activation: either the `META-INF/spring.factories` file is in your test resources, or the annotations are present on your test classes - see [Getting Started](Getting-Started.md#2-activate-the-profiler).
+3. Make sure at least one **Spring** test ran (a plain unit test without a Spring context does not trigger the profiler).
+4. Check for a custom `pragmatech.spring.test.insight.report.dir` property pointing somewhere unexpected - see [Configuration Reference](Configuration-Reference.md).
+
+### The Report Shows Fewer Contexts Than Expected
+
+Spring's context cache holds 32 contexts by default and evicts least recently used entries beyond that. The profiler tracks contexts independently of this limit, but if numbers still look off, check whether your tests ran in parallel (see limitations above).
+
+### Two Contexts Look Identical but Are Not Shared
+
+Open the context configuration comparison in the report - one attribute (profiles, properties, customizers, initializers) will differ. If the differing attribute is a context customizer that renders only as a class name, add a [context customizer extension](Advanced-Usage.md#custom-context-customizer-descriptions) to expose its configuration details. Background: [Spring Context Caching](Spring-Context-Caching.md).
+
+## Reporting Bugs
+
+Found a bug? Please help us improve by reporting it:
+
+1. **Search existing issues** at https://github.com/PragmaTech-GmbH/spring-test-profiler/issues
+2. **Create a new issue** with:
+   - Clear description of the problem
+   - Steps to reproduce
+   - Expected vs actual behavior
+   - Java/Spring/JUnit versions
+   - Relevant log output or screenshots
+
+A minimal reproducer project is the fastest path to a fix - consider forking one of the [demo projects](Demo-Projects.md) as a starting point.

--- a/docs/wiki/Understanding-the-Report.md
+++ b/docs/wiki/Understanding-the-Report.md
@@ -10,7 +10,11 @@ You can also explore a hosted [demo report](https://pragmatech.digital/products/
 
 ## Test Execution Summary
 
-The top of the report shows the overall picture of your test run: how many test classes and methods ran, their outcomes, and the total execution time. Use this as a baseline - the goal of every optimization is to bring the total time down without losing coverage.
+The top of the report shows the overall picture of your test run: how many test classes and methods ran, their outcomes, the total execution time, and the total number of Spring contexts created. Use this as a baseline - the goal of every optimization is to bring the total time and the context count down without losing coverage.
+
+## How Context Caching Works (Theory Section)
+
+The report includes a theory section that explains Spring's context caching mechanism with an animation: Spring scans the test configuration, builds a cache key from the `MergedContextConfiguration` hashCode, and reuses matching application contexts. For the full background, see [Spring Context Caching](Spring-Context-Caching.md).
 
 ## Spring Context Caching Statistics
 
@@ -34,9 +38,9 @@ If a context customizer's default description is too generic to explain a differ
 
 ## Context Lifecycle Timeline
 
-The timeline visualizes when each context was created and how test execution proceeded around it. This helps you see context creation bursts, for example at the start of an integration test phase.
+The timeline visualizes the context cache over time: when each context was created, when contexts were removed from the cache, and how test execution proceeded around them. This helps you see context creation bursts, for example at the start of an integration test phase, and cache evictions caused by the cache size limit.
 
-Note: the timeline visualization is still under development - see [Troubleshooting and Limitations](Troubleshooting-and-Limitations.md).
+Note: the timeline visualization is still evolving - see [Troubleshooting and Limitations](Troubleshooting-and-Limitations.md).
 
 ## Optimization Recommendations
 

--- a/docs/wiki/Understanding-the-Report.md
+++ b/docs/wiki/Understanding-the-Report.md
@@ -1,0 +1,49 @@
+# Understanding the Report
+
+After a test run, open `target/spring-test-profiler/latest.html` (Maven) or `build/spring-test-profiler/latest.html` (Gradle). This page walks through the report from top to bottom.
+
+You can also explore a hosted [demo report](https://pragmatech.digital/products/spring-test-profiler/) without running anything.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/PragmaTech-GmbH/spring-test-profiler/main/docs/report-full.png" alt="Full Spring Test Profiler Report" width="600" />
+</p>
+
+## Test Execution Summary
+
+The top of the report shows the overall picture of your test run: how many test classes and methods ran, their outcomes, and the total execution time. Use this as a baseline - the goal of every optimization is to bring the total time down without losing coverage.
+
+## Spring Context Caching Statistics
+
+This section surfaces the core caching metrics:
+
+- **Cache hits and misses** - how often a test could reuse an already-loaded application context versus having to start a new one
+- **Context load times** - how expensive each context creation was
+- **Cache hit rate** - the single most important number: a low hit rate usually means your test configurations differ in ways that prevent reuse
+
+The profiler tracks these metrics independently of Spring's internal statistics, so the numbers stay accurate even beyond Spring's default cache size limit of 32 contexts (see [Spring Context Caching](Spring-Context-Caching.md)).
+
+## Context Cache Entries
+
+Each cached application context is listed with the test classes that used it, its configuration attributes, and its load time. Sorting controls let you order entries, for example by load time, to find the most expensive contexts first.
+
+## Spring Context Configurations
+
+When two contexts look similar but were not shared, this section shows an attribute-by-attribute comparison of their `MergedContextConfiguration` - profiles, property sources, context initializers, context customizers, and more. The diff view aligns attributes across contexts so you can spot the exact difference that caused Spring to create a separate context.
+
+If a context customizer's default description is too generic to explain a difference (common with WireMock and similar tools), you can plug in a [context customizer extension](Advanced-Usage.md#custom-context-customizer-descriptions) to render meaningful details.
+
+## Context Lifecycle Timeline
+
+The timeline visualizes when each context was created and how test execution proceeded around it. This helps you see context creation bursts, for example at the start of an integration test phase.
+
+Note: the timeline visualization is still under development - see [Troubleshooting and Limitations](Troubleshooting-and-Limitations.md).
+
+## Optimization Recommendations
+
+The report closes with actionable guidance:
+
+- **Top optimization opportunities** - test classes or configurations where harmonizing settings would let contexts be shared
+- **Potential impact analysis** - an estimate of how much build time you could save
+- **Optimization tips** - general practices for maximizing context reuse
+
+Typical wins include removing unnecessary `@DirtiesContext`, consolidating `@MockBean`/`@MockitoBean` usage into shared test configurations, and aligning active profiles and property sources across test classes.

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,0 +1,1 @@
+This wiki is generated from the [`docs/wiki`](https://github.com/PragmaTech-GmbH/spring-test-profiler/tree/main/docs/wiki) directory - please edit via pull request. Changes made through the wiki UI are overwritten on the next sync.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,22 @@
+**[Home](Home.md)**
+
+**Getting Started**
+
+- [Getting Started](Getting-Started.md)
+- [Understanding the Report](Understanding-the-Report.md)
+- [Spring Context Caching](Spring-Context-Caching.md)
+
+**Reference**
+
+- [Configuration Reference](Configuration-Reference.md)
+- [Troubleshooting and Limitations](Troubleshooting-and-Limitations.md)
+
+**Advanced**
+
+- [Advanced Usage](Advanced-Usage.md)
+
+**Project**
+
+- [New Features](New-Features.md)
+- [Demo Projects](Demo-Projects.md)
+- [Contributing](Contributing.md)

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -18,21 +18,23 @@ echo "🔄 Updating versions..."
 echo "Release version: $RELEASE_VERSION"
 echo "Next dev version: $NEXT_DEV_VERSION"
 
-# Update README.md with release version
-echo "📝 Updating README.md with release version..."
+# Update README.md and wiki docs with release version
+echo "📝 Updating README.md and docs/wiki with release version..."
 # Use cross-platform sed approach
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # macOS
-  sed -i "" "s/Latest%20Version-[0-9]*\.[0-9]*\.[0-9]*/Latest%20Version-$RELEASE_VERSION/" README.md
-  sed -i "" "s/<version>[0-9]*\.[0-9]*\.[0-9]*<\/version>/<version>$RELEASE_VERSION<\/version>/" README.md
-  sed -i "" "s/spring-test-profiler:[0-9]*\.[0-9]*\.[0-9]*/spring-test-profiler:$RELEASE_VERSION/" README.md
-else
-  # Linux
-  sed -i "s/Latest%20Version-[0-9]*\.[0-9]*\.[0-9]*/Latest%20Version-$RELEASE_VERSION/" README.md
-  sed -i "s/<version>[0-9]*\.[0-9]*\.[0-9]*<\/version>/<version>$RELEASE_VERSION<\/version>/" README.md
-  sed -i "s/spring-test-profiler:[0-9]*\.[0-9]*\.[0-9]*/spring-test-profiler:$RELEASE_VERSION/" README.md
-fi
-echo "✅ Updated README.md with release version $RELEASE_VERSION"
+for docFile in README.md docs/wiki/Getting-Started.md; do
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    sed -i "" "s/Latest%20Version-[0-9]*\.[0-9]*\.[0-9]*/Latest%20Version-$RELEASE_VERSION/" "$docFile"
+    sed -i "" "s/<version>[0-9]*\.[0-9]*\.[0-9]*<\/version>/<version>$RELEASE_VERSION<\/version>/" "$docFile"
+    sed -i "" "s/spring-test-profiler:[0-9]*\.[0-9]*\.[0-9]*/spring-test-profiler:$RELEASE_VERSION/" "$docFile"
+  else
+    # Linux
+    sed -i "s/Latest%20Version-[0-9]*\.[0-9]*\.[0-9]*/Latest%20Version-$RELEASE_VERSION/" "$docFile"
+    sed -i "s/<version>[0-9]*\.[0-9]*\.[0-9]*<\/version>/<version>$RELEASE_VERSION<\/version>/" "$docFile"
+    sed -i "s/spring-test-profiler:[0-9]*\.[0-9]*\.[0-9]*/spring-test-profiler:$RELEASE_VERSION/" "$docFile"
+  fi
+  echo "✅ Updated $docFile with release version $RELEASE_VERSION"
+done
 
 # Set next development version in main pom.xml
 echo "📝 Updating main pom.xml to next development version..."


### PR DESCRIPTION
## Summary

Makes `docs/wiki/` in the repo the single source of truth for full documentation, synced automatically to the GitHub wiki, and slims the README down to pitch + quick start.

- **12 new wiki pages** under `docs/wiki/`: Home, Getting Started, Understanding the Report, Spring Context Caching, Configuration Reference (first documentation of the `spring.test.insight.json.beta` and `pragmatech.spring.test.insight.report.dir` system properties), Advanced Usage (context customizer extension guide moved from the README), New Features (curated release highlights), Demo Projects, Troubleshooting and Limitations, Contributing, plus `_Sidebar` and `_Footer`
- **New workflow** `.github/workflows/publish-wiki.yml`: uses `Andrew-Chen-Wang/github-wiki-action@v5` with `strategy: init` to force-push `docs/wiki/` to the wiki on every push to `main` touching `docs/wiki/**` - one-way sync, the repo strictly wins over wiki UI edits (the wiki footer says so)
- **README slimmed**: new Documentation section linking to the wiki; the customizer-extension deep dive, limitations list, bug reporting, and contributing sections replaced with pointers to the wiki; the 4-step quick start stays intact
- **`scripts/update-versions.sh`**: release-time version rewrite now also covers `docs/wiki/Getting-Started.md` so wiki install snippets stay current

## Notes

- The wiki feature is enabled and a sample page exists, so the sync will work on the first push to `main` after merge
- Wiki inter-page links use relative `.md` paths: they render in the GitHub repo view and the action's preprocessing rewrites them to wiki page references
- Screenshots are referenced via absolute raw URLs so they render both in the repo and on the wiki

## Test plan

- [x] `actionlint` passes on the new workflow
- [x] `bash -n` passes on the updated version script
- [x] No content duplicated between README and wiki (deep-dive sections fully moved)
- [ ] After merge: verify the "Publish Wiki" workflow run populates the wiki, spot-check sidebar, footer, images, and inter-page links

🤖 Generated with [Claude Code](https://claude.com/claude-code)