### PR TITLE
feat(ci): visual regression check for the HTML report on pull requests

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,209 @@
+name: Visual Regression
+
+# Report-only check: renders the profiler HTML report built from this PR next to the
+# report produced by the latest version published to Maven Central and posts the pixel
+# diff as a PR comment. Visual differences never fail this job - only infrastructure
+# errors do. Do not mark this check as required in branch protection.
+
+on:
+  pull_request:
+    paths:
+      - 'src/main/**'
+      - 'demo/spring-boot-3.5-maven/**'
+      - 'visual-regression/**'
+      - '.github/workflows/visual-regression.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: visual-regression-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  DEMO_DIR: demo/spring-boot-3.5-maven
+
+jobs:
+  visual-regression:
+    name: Compare report against latest release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21'
+          cache: 'npm'
+          cache-dependency-path: 'visual-regression/package-lock.json'
+
+      - name: Resolve latest Maven Central release
+        id: baseline
+        run: |
+          metadataUrl="https://repo1.maven.org/maven2/digital/pragmatech/testing/spring-test-profiler/maven-metadata.xml"
+          baselineVersion="$(curl -sf "$metadataUrl" | sed -n 's/.*<release>\(.*\)<\/release>.*/\1/p' | head -1 || true)"
+          if [ -z "$baselineVersion" ]; then
+            echo "Could not determine the latest release from Maven Central - skipping visual comparison"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Baseline version: $baselineVersion"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "version=$baselineVersion" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run demo with released profiler (baseline)
+        if: steps.baseline.outputs.skip != 'true'
+        working-directory: ${{ env.DEMO_DIR }}
+        run: |
+          ./mvnw -q versions:use-dep-version \
+            -Dincludes=digital.pragmatech.testing:spring-test-profiler \
+            -DdepVersion="${{ steps.baseline.outputs.version }}" \
+            -DforceVersion=true -DgenerateBackupPoms=false
+          ./mvnw -q clean verify
+          mkdir -p "$GITHUB_WORKSPACE/visual-regression/work"
+          cp target/spring-test-profiler/latest.html "$GITHUB_WORKSPACE/visual-regression/work/baseline.html"
+          git checkout -- pom.xml
+
+      - name: Build PR profiler
+        if: steps.baseline.outputs.skip != 'true'
+        id: current
+        run: |
+          ./mvnw -q clean install -DskipTests
+          currentVersion="$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          echo "Current version: $currentVersion"
+          echo "version=$currentVersion" >> "$GITHUB_OUTPUT"
+
+      - name: Run demo with PR profiler (current)
+        if: steps.baseline.outputs.skip != 'true'
+        working-directory: ${{ env.DEMO_DIR }}
+        run: |
+          ./mvnw -q clean verify
+          cp target/spring-test-profiler/latest.html "$GITHUB_WORKSPACE/visual-regression/work/current.html"
+
+      - name: Install comparison harness
+        if: steps.baseline.outputs.skip != 'true'
+        working-directory: visual-regression
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Compare reports
+        if: steps.baseline.outputs.skip != 'true'
+        working-directory: visual-regression
+        run: |
+          node compare-reports.mjs \
+            --baseline work/baseline.html \
+            --current work/current.html \
+            --out work/out \
+            --baseline-version "${{ steps.baseline.outputs.version }}" \
+            --current-version "${{ steps.current.outputs.version }}"
+
+      - name: Upload comparison artifacts
+        if: always() && steps.baseline.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-report
+          path: visual-regression/work/
+          if-no-files-found: ignore
+
+      - name: Publish result
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          BASELINE_SKIPPED: ${{ steps.baseline.outputs.skip }}
+          BASELINE_VERSION: ${{ steps.baseline.outputs.version }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- spring-test-profiler-visual-regression -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            let body;
+            if (process.env.BASELINE_SKIPPED === 'true') {
+              body = [
+                marker,
+                '## Visual Regression Check',
+                '',
+                'Skipped - could not determine the latest release from Maven Central.',
+              ].join('\n');
+            } else {
+              let summary;
+              try {
+                summary = JSON.parse(fs.readFileSync('visual-regression/work/out/summary.json', 'utf8'));
+              } catch (error) {
+                summary = null;
+              }
+              if (summary === null) {
+                body = [
+                  marker,
+                  '## Visual Regression Check',
+                  '',
+                  `The comparison did not produce a result - see the [workflow run](${runUrl}) for details.`,
+                ].join('\n');
+              } else {
+                const emoji = { identical: '✅', minor: 'ℹ️', notable: '⚠️' }[summary.classification] ?? '❓';
+                const diffPercent = (summary.diffRatio * 100).toFixed(3);
+                body = [
+                  marker,
+                  '## Visual Regression Check',
+                  '',
+                  `${emoji} Report comparison against the latest Maven Central release: **${summary.classification}**`,
+                  '',
+                  '| | |',
+                  '|---|---|',
+                  `| Baseline (Maven Central) | \`${summary.baselineVersion}\` |`,
+                  `| Current (this PR) | \`${summary.currentVersion}\` |`,
+                  `| Differing pixels | ${summary.diffPixels.toLocaleString('en-US')} of ${summary.totalPixels.toLocaleString('en-US')} (${diffPercent}%) |`,
+                  '',
+                  `Before/after screenshots, \`diff.png\`, and both HTML reports are attached as the`,
+                  `\`visual-regression-report\` artifact on the [workflow run](${runUrl}).`,
+                  '',
+                  '_This check is informational and never blocks a merge. It shows how the report',
+                  'rendered from this PR differs from what the latest released version produces._',
+                ].join('\n');
+              }
+            }
+
+            await core.summary.addRaw(body.replace(marker, '')).write();
+
+            const isSameRepoPr =
+              context.eventName === 'pull_request' &&
+              context.payload.pull_request.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+            if (!isSameRepoPr) {
+              core.info('Not a same-repository pull request - skipping PR comment (result is in the step summary).');
+              return;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const existingComment = comments.find((comment) => comment.body?.includes(marker));
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -7,6 +7,7 @@ name: Visual Regression
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     paths:
       - 'src/main/**'
       - 'demo/spring-boot-3.5-maven/**'
@@ -14,8 +15,10 @@ on:
       - '.github/workflows/visual-regression.yml'
   workflow_dispatch:
 
+# contents: write is needed to push the screenshots to a per-PR assets branch so the
+# PR comment can embed them as images (the GitHub API cannot attach files to comments).
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 concurrency:
@@ -28,6 +31,7 @@ env:
 jobs:
   visual-regression:
     name: Compare report against latest release
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
 
     steps:
@@ -117,12 +121,41 @@ jobs:
           path: visual-regression/work/
           if-no-files-found: ignore
 
+      # Comments cannot carry file attachments, so the screenshots are force-pushed to a
+      # per-PR orphan branch and embedded via raw.githubusercontent.com URLs pinned to
+      # the commit SHA (avoids stale image caching). The branch is deleted on PR close.
+      - name: Publish screenshots for PR comment
+        id: assets
+        if: >-
+          steps.baseline.outputs.skip != 'true' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          assetsDir="$(mktemp -d)"
+          cp visual-regression/work/out/baseline.png \
+             visual-regression/work/out/current.png \
+             visual-regression/work/out/diff.png "$assetsDir"
+          cd "$assetsDir"
+          git init -q -b assets
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -q -m "Visual regression screenshots for PR #${PR_NUMBER} (run ${{ github.run_id }})"
+          git push -q --force \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" \
+            "HEAD:refs/heads/visual-regression-assets-pr-${PR_NUMBER}"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Publish result
         if: always()
         uses: actions/github-script@v7
         env:
           BASELINE_SKIPPED: ${{ steps.baseline.outputs.skip }}
           BASELINE_VERSION: ${{ steps.baseline.outputs.version }}
+          ASSETS_SHA: ${{ steps.assets.outputs.sha }}
         with:
           script: |
             const fs = require('fs');
@@ -154,6 +187,34 @@ jobs:
               } else {
                 const emoji = { identical: '✅', minor: 'ℹ️', notable: '⚠️' }[summary.classification] ?? '❓';
                 const diffPercent = (summary.diffRatio * 100).toFixed(3);
+                const assetsSha = process.env.ASSETS_SHA;
+                let imageSection;
+                if (assetsSha) {
+                  const rawBase = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/${assetsSha}`;
+                  imageSection = [
+                    '<details open>',
+                    '<summary><strong>Visual diff</strong> (changed pixels highlighted)</summary>',
+                    '',
+                    `![Visual diff](${rawBase}/diff.png)`,
+                    '',
+                    '</details>',
+                    '',
+                    '<details>',
+                    '<summary><strong>Baseline vs. current</strong> (side by side)</summary>',
+                    '',
+                    '<table><tr>',
+                    `<th>Baseline (${summary.baselineVersion})</th>`,
+                    `<th>Current (${summary.currentVersion})</th>`,
+                    '</tr><tr>',
+                    `<td><img src="${rawBase}/baseline.png" alt="Baseline report"></td>`,
+                    `<td><img src="${rawBase}/current.png" alt="Current report"></td>`,
+                    '</tr></table>',
+                    '',
+                    '</details>',
+                  ].join('\n');
+                } else {
+                  imageSection = '';
+                }
                 body = [
                   marker,
                   '## Visual Regression Check',
@@ -166,7 +227,9 @@ jobs:
                   `| Current (this PR) | \`${summary.currentVersion}\` |`,
                   `| Differing pixels | ${summary.diffPixels.toLocaleString('en-US')} of ${summary.totalPixels.toLocaleString('en-US')} (${diffPercent}%) |`,
                   '',
-                  `Before/after screenshots, \`diff.png\`, and both HTML reports are attached as the`,
+                  imageSection,
+                  '',
+                  `Both HTML reports and the raw screenshots are also attached as the`,
                   `\`visual-regression-report\` artifact on the [workflow run](${runUrl}).`,
                   '',
                   '_This check is informational and never blocks a merge. It shows how the report',
@@ -206,4 +269,29 @@ jobs:
                 issue_number: context.payload.pull_request.number,
                 body,
               });
+            }
+
+  cleanup-assets:
+    name: Delete screenshot assets branch
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete assets branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = `visual-regression-assets-pr-${context.payload.pull_request.number}`;
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`,
+              });
+              core.info(`Deleted ${branch}`);
+            } catch (error) {
+              if (error.status === 422 || error.status === 404) {
+                core.info(`${branch} does not exist - nothing to clean up`);
+              } else {
+                throw error;
+              }
             }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,15 @@ mvn clean verify
 # View reports at: target/spring-test-profiler/latest.html
 ```
 
+### Visual Regression Check
+
+```bash
+# Compare the report rendered from the local working tree against the latest Maven Central release
+./visual-regression/run-local.sh
+```
+
+The same comparison runs on pull requests via `.github/workflows/visual-regression.yml` (report-only, never blocks a merge).
+
 ### Development Testing
 
 ```bash

--- a/visual-regression/.gitignore
+++ b/visual-regression/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+work/

--- a/visual-regression/compare-reports.mjs
+++ b/visual-regression/compare-reports.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+// Compares two spring-test-profiler HTML reports visually.
+//
+// Both reports contain run-specific content (timestamps, durations, memory figures,
+// version strings) that would show up as noise in a pixel comparison. The script
+// normalizes that content in both files, renders each in headless Chromium, and
+// pixel-compares the full-page screenshots.
+//
+// Exit code 0 regardless of the visual diff (report-only check); non-zero only on
+// crashes (missing input, browser failure).
+
+import { createServer } from 'node:http';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { PNG } from 'pngjs';
+import pixelmatch from 'pixelmatch';
+import { chromium } from 'playwright';
+
+const FIXED_TIMESTAMP = '2000-01-01 00:00:00';
+const FIXED_EPOCH_SECONDS = 946684800;
+const FIXED_LOAD_DURATION_MS = 1000;
+const VIEWPORT = { width: 1400, height: 900 };
+const D3_SETTLE_MS = 2000;
+const PIXELMATCH_THRESHOLD = 0.1;
+const MINOR_DIFF_RATIO = 0.005;
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key?.startsWith('--') || value === undefined) {
+      throw new Error(`Invalid argument pair: ${key} ${value}`);
+    }
+    args[key.slice(2)] = value;
+  }
+  const required = ['baseline', 'current', 'out', 'baseline-version', 'current-version'];
+  for (const name of required) {
+    if (!args[name]) {
+      throw new Error(
+        `Missing --${name}. Usage: node compare-reports.mjs --baseline <html> --current <html> ` +
+          '--out <dir> --baseline-version <v> --current-version <v>'
+      );
+    }
+  }
+  return args;
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// The report assigns "context-N" keys in test execution order, which is not stable
+// across runs. Sorts the embedded statistics entries by their content and renumbers
+// the keys, then applies the same renumbering to every "context-N" token in the HTML
+// (the caching section displays them and the report JS cross-references them).
+function canonicalizeStatisticsJson(html) {
+  const keyMapping = new Map();
+
+  let normalized = html.replace(
+    /(<script type="application\/json" id="context-statistics-json"[^>]*>)([\s\S]*?)(<\/script>)/,
+    (match, openTag, jsonText, closeTag) => {
+      const statistics = JSON.parse(jsonText.trim() || '[]');
+      const normalizeEntry = (entry) => {
+        if (Array.isArray(entry)) {
+          entry.forEach(normalizeEntry);
+        } else if (entry && typeof entry === 'object') {
+          if ('loadDuration' in entry) entry.loadDuration = FIXED_LOAD_DURATION_MS;
+          if ('initialLoadTime' in entry) entry.initialLoadTime = FIXED_EPOCH_SECONDS;
+          if ('lastUsedTime' in entry) entry.lastUsedTime = FIXED_EPOCH_SECONDS;
+          Object.values(entry).forEach(normalizeEntry);
+        }
+      };
+      normalizeEntry(statistics);
+      const contentKey = (entry) => JSON.stringify({ ...entry, contextKey: undefined });
+      statistics.sort((a, b) => contentKey(a).localeCompare(contentKey(b)));
+      statistics.forEach((entry, index) => {
+        if (entry?.contextKey) {
+          keyMapping.set(entry.contextKey, `context-${index}`);
+        }
+      });
+      return openTag + JSON.stringify(statistics) + closeTag;
+    }
+  );
+
+  // Two-pass replacement so overlapping renames (context-1 -> context-3 while
+  // context-3 -> context-1) cannot clobber each other.
+  let placeholderIndex = 0;
+  const placeholders = [];
+  for (const [oldKey, newKey] of keyMapping) {
+    const placeholder = `@@context-placeholder-${placeholderIndex++}@@`;
+    placeholders.push([placeholder, newKey]);
+    normalized = normalized.replace(new RegExp(`\\b${escapeRegExp(oldKey)}\\b`, 'g'), placeholder);
+  }
+  for (const [placeholder, newKey] of placeholders) {
+    normalized = normalized.replaceAll(placeholder, newKey);
+  }
+  return normalized;
+}
+
+function normalizeHtml(html, versionTokens) {
+  let normalized = html;
+
+  // Fix the D3 chart inputs and context identities first so chart geometry and
+  // context labels are deterministic.
+  normalized = canonicalizeStatisticsJson(normalized);
+
+  // Version strings (footer <span> and utm_content query parameters).
+  for (const version of versionTokens) {
+    normalized = normalized.replaceAll(version, 'X.Y.Z');
+  }
+
+  // Generated-at timestamps (header, footer, summary "Execution Time").
+  normalized = normalized.replace(/\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}/g, FIXED_TIMESTAMP);
+
+  // Heap memory stat rows render only when heapMemoryUsedBytes > 0, so one report
+  // may contain them and the other not; drop them entirely to avoid layout noise.
+  normalized = normalized.replace(
+    /<div class="stat-row">\s*<span class="stat-label">Heap Memory:<\/span>[\s\S]*?<\/div>/g,
+    ''
+  );
+
+  // Load-time data attributes consumed by the report JS.
+  normalized = normalized.replace(/data-load-time-ms="\d+"/g, 'data-load-time-ms="0"');
+
+  // DurationFormatter output: "123ms", "1.2s", "1.5m" (plus raw "...ms" concatenations).
+  normalized = normalized.replace(/\b\d+(\.\d+)?(ms|s|m)\b/g, '0ms');
+
+  // Any remaining memory figures.
+  normalized = normalized.replace(/\b\d+(\.\d+)?\s?MB\b/g, '0.0MB');
+
+  return normalized;
+}
+
+function serveDirectory(directory) {
+  return new Promise((resolvePromise) => {
+    const server = createServer((request, response) => {
+      try {
+        const content = readFileSync(resolve(directory, '.' + request.url));
+        response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        response.end(content);
+      } catch {
+        response.writeHead(404);
+        response.end('Not found');
+      }
+    });
+    server.listen(0, '127.0.0.1', () => resolvePromise(server));
+  });
+}
+
+async function screenshotPage(browser, url, outputPath) {
+  const page = await browser.newPage({ viewport: VIEWPORT, deviceScaleFactor: 1 });
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(D3_SETTLE_MS);
+
+  // Cache entries and context configurations are rendered from unordered maps, so
+  // their document order differs between runs. Sort them by content after the report
+  // JS has rendered, and renumber the display-only "config-N" labels.
+  await page.evaluate(() => {
+    const sortSiblings = (selector, keyOf) => {
+      const byParent = new Map();
+      for (const element of document.querySelectorAll(selector)) {
+        const siblings = byParent.get(element.parentElement) ?? [];
+        siblings.push(element);
+        byParent.set(element.parentElement, siblings);
+      }
+      for (const [parent, elements] of byParent) {
+        elements.sort((a, b) => keyOf(a).localeCompare(keyOf(b), 'en', { numeric: true }));
+        for (const element of elements) {
+          parent.appendChild(element);
+        }
+      }
+    };
+    sortSiblings('.cache-entry', (el) => el.querySelector('.cache-id')?.textContent ?? el.textContent);
+    sortSiblings('.context-config-item', (el) => el.textContent.replace(/config-\d+/g, ''));
+    document
+      .querySelectorAll('.context-config-item .context-config-id span')
+      .forEach((span, index) => (span.textContent = `config-${index}`));
+  });
+
+  await page.screenshot({ path: outputPath, fullPage: true, animations: 'disabled' });
+  await page.close();
+}
+
+// Pads an image to the target size with magenta so added/removed content at the
+// bottom of the longer report counts as a visual difference.
+function padImage(image, targetWidth, targetHeight) {
+  if (image.width === targetWidth && image.height === targetHeight) {
+    return image;
+  }
+  const padded = new PNG({ width: targetWidth, height: targetHeight });
+  for (let y = 0; y < targetHeight; y++) {
+    for (let x = 0; x < targetWidth; x++) {
+      const targetIndex = (targetWidth * y + x) << 2;
+      if (x < image.width && y < image.height) {
+        const sourceIndex = (image.width * y + x) << 2;
+        padded.data[targetIndex] = image.data[sourceIndex];
+        padded.data[targetIndex + 1] = image.data[sourceIndex + 1];
+        padded.data[targetIndex + 2] = image.data[sourceIndex + 2];
+        padded.data[targetIndex + 3] = image.data[sourceIndex + 3];
+      } else {
+        padded.data[targetIndex] = 255;
+        padded.data[targetIndex + 1] = 0;
+        padded.data[targetIndex + 2] = 255;
+        padded.data[targetIndex + 3] = 255;
+      }
+    }
+  }
+  return padded;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const outputDir = resolve(args.out);
+  mkdirSync(outputDir, { recursive: true });
+
+  const versionTokens = [args['baseline-version'], args['current-version']];
+  const inputs = [
+    { label: 'baseline', htmlPath: resolve(args.baseline) },
+    { label: 'current', htmlPath: resolve(args.current) },
+  ];
+
+  for (const input of inputs) {
+    const html = readFileSync(input.htmlPath, 'utf8');
+    input.normalizedName = `${input.label}.normalized.html`;
+    writeFileSync(resolve(outputDir, input.normalizedName), normalizeHtml(html, versionTokens));
+  }
+
+  const server = await serveDirectory(outputDir);
+  const port = server.address().port;
+  const browser = await chromium.launch();
+  try {
+    for (const input of inputs) {
+      input.screenshotPath = resolve(outputDir, `${input.label}.png`);
+      await screenshotPage(browser, `http://127.0.0.1:${port}/${input.normalizedName}`, input.screenshotPath);
+      console.log(`Captured ${basename(input.screenshotPath)}`);
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  const baselineImage = PNG.sync.read(readFileSync(inputs[0].screenshotPath));
+  const currentImage = PNG.sync.read(readFileSync(inputs[1].screenshotPath));
+  const width = Math.max(baselineImage.width, currentImage.width);
+  const height = Math.max(baselineImage.height, currentImage.height);
+  const paddedBaseline = padImage(baselineImage, width, height);
+  const paddedCurrent = padImage(currentImage, width, height);
+
+  const diffImage = new PNG({ width, height });
+  const diffPixels = pixelmatch(paddedBaseline.data, paddedCurrent.data, diffImage.data, width, height, {
+    threshold: PIXELMATCH_THRESHOLD,
+  });
+  writeFileSync(resolve(outputDir, 'diff.png'), PNG.sync.write(diffImage));
+
+  const totalPixels = width * height;
+  const diffRatio = diffPixels / totalPixels;
+  const classification =
+    diffPixels === 0 ? 'identical' : diffRatio < MINOR_DIFF_RATIO ? 'minor' : 'notable';
+
+  const summary = {
+    baselineVersion: args['baseline-version'],
+    currentVersion: args['current-version'],
+    width,
+    height,
+    totalPixels,
+    diffPixels,
+    diffRatio,
+    classification,
+  };
+  writeFileSync(resolve(outputDir, 'summary.json'), JSON.stringify(summary, null, 2) + '\n');
+
+  console.log(
+    `Visual comparison: ${diffPixels} of ${totalPixels} pixels differ ` +
+      `(${(diffRatio * 100).toFixed(3)}%) - ${classification}`
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/visual-regression/package-lock.json
+++ b/visual-regression/package-lock.json
@@ -1,0 +1,80 @@
+{
+  "name": "spring-test-profiler-visual-regression",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "spring-test-profiler-visual-regression",
+      "dependencies": {
+        "pixelmatch": "^6.0.0",
+        "playwright": "^1.53.0",
+        "pngjs": "^7.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-6.0.0.tgz",
+      "integrity": "sha512-FYpL4XiIWakTnIqLqvt3uN4L9B3TsuHIvhLILzTiJZMJUsGvmKNeL4H3b6I99LRyerK9W4IuOXw+N28AtRgK2g==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    }
+  }
+}

--- a/visual-regression/package.json
+++ b/visual-regression/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "spring-test-profiler-visual-regression",
+  "private": true,
+  "type": "module",
+  "description": "Visual comparison of the profiler HTML report between the PR build and the latest Maven Central release",
+  "scripts": {
+    "compare": "node compare-reports.mjs"
+  },
+  "dependencies": {
+    "pixelmatch": "^6.0.0",
+    "playwright": "^1.53.0",
+    "pngjs": "^7.0.0"
+  }
+}

--- a/visual-regression/run-local.sh
+++ b/visual-regression/run-local.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Runs the same visual comparison as .github/workflows/visual-regression.yml locally:
+# demo report built against the latest Maven Central release vs. the local working tree.
+#
+# Usage: ./visual-regression/run-local.sh [baseline-version]
+#   baseline-version defaults to the <release> version from Maven Central metadata.
+
+set -euo pipefail
+
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repoRoot="$(cd "$scriptDir/.." && pwd)"
+demoDir="$repoRoot/demo/spring-boot-3.5-maven"
+workDir="$scriptDir/work"
+
+restoreDemoPom() {
+  git -C "$repoRoot" checkout -- "$demoDir/pom.xml" 2>/dev/null || true
+}
+trap restoreDemoPom EXIT
+
+baselineVersion="${1:-}"
+if [ -z "$baselineVersion" ]; then
+  metadataUrl="https://repo1.maven.org/maven2/digital/pragmatech/testing/spring-test-profiler/maven-metadata.xml"
+  baselineVersion="$(curl -sf "$metadataUrl" | sed -n 's/.*<release>\(.*\)<\/release>.*/\1/p' | head -1)"
+fi
+if [ -z "$baselineVersion" ]; then
+  echo "Could not determine the latest released version from Maven Central" >&2
+  exit 1
+fi
+
+currentVersion="$(cd "$repoRoot" && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)"
+echo "Baseline: $baselineVersion (Maven Central), current: $currentVersion (local build)"
+
+mkdir -p "$workDir"
+
+echo "==> Running demo with released profiler $baselineVersion"
+(
+  cd "$demoDir"
+  ./mvnw -q versions:use-dep-version \
+    -Dincludes=digital.pragmatech.testing:spring-test-profiler \
+    -DdepVersion="$baselineVersion" -DforceVersion=true -DgenerateBackupPoms=false
+  ./mvnw -q clean verify
+)
+cp "$demoDir/target/spring-test-profiler/latest.html" "$workDir/baseline.html"
+restoreDemoPom
+
+echo "==> Building local profiler $currentVersion"
+(cd "$repoRoot" && ./mvnw -q clean install -DskipTests)
+
+echo "==> Running demo with local profiler $currentVersion"
+(cd "$demoDir" && ./mvnw -q clean verify)
+cp "$demoDir/target/spring-test-profiler/latest.html" "$workDir/current.html"
+
+echo "==> Comparing reports"
+cd "$scriptDir"
+npm install
+npx playwright install chromium
+node compare-reports.mjs \
+  --baseline work/baseline.html \
+  --current work/current.html \
+  --out work/out \
+  --baseline-version "$baselineVersion" \
+  --current-version "$currentVersion"
+
+cat "$workDir/out/summary.json"
+if [ "$(uname)" = "Darwin" ]; then
+  open "$workDir/out/diff.png"
+fi


### PR DESCRIPTION
## Summary

Adds a report-only visual regression check that runs on pull requests: it renders the profiler HTML report built from the PR next to the report produced by the **latest version published to Maven Central**, screenshots both with Playwright, pixel-compares them, and posts the result as a PR comment. It answers "how will the report change visually compared to what users currently get?" before a release, without gating the release workflow itself.

## How it works

- `.github/workflows/visual-regression.yml` (triggered by PRs touching `src/main/**`, the `spring-boot-3.5-maven` demo, or the harness):
  1. Resolves the latest release from Maven Central metadata (currently `0.1.2`); skips gracefully if unavailable.
  2. Runs the demo against that release (`versions:use-dep-version`, pom restored afterwards), then against the PR-built jar - sequentially on the same runner, so environment-dependent content matches.
  3. `visual-regression/compare-reports.mjs` normalizes both reports, screenshots them in headless Chromium, and pixel-compares with pixelmatch.
  4. Uploads before/after/diff images plus both HTML reports as the `visual-regression-report` artifact and upserts a single PR comment (step summary fallback for fork PRs).
- **Report-only**: visual diffs never fail the job, only infrastructure errors do. Do not mark the check as required.
- `./visual-regression/run-local.sh` runs the identical comparison locally.

## Normalization

The report contains run-specific content that would drown a pixel diff in noise. The harness normalizes timestamps, durations, memory figures, and version strings, and canonicalizes the non-deterministic `context-N`/`config-N` identity assignment (ids are handed out in test execution order and rendered from unordered maps): statistics entries are sorted by content and renumbered consistently across the embedded JSON and the HTML, and cache-entry/configuration blocks are sorted in the DOM before screenshotting.

## Verification (run locally)

- Two same-version runs with different test execution orders: **0.000% diff** (twice)
- Released `0.1.2` vs current `0.1.3-SNAPSHOT`: **0.000% diff** (no visual changes since the last release)
- Injected CSS change (heading color + card borders): **4.6% diff** with a readable diff image

This PR touches `src/main`-adjacent paths itself, so the new workflow should run right here as a live end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)