### PR TITLE
fix(release): hide Claude co-author from release notes contributors

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -38,6 +38,7 @@ release:
         contributors:
           - '[bot]'
           - 'GitHub'
+          - 'Claude'
 deploy:
   maven:
     mavenCentral:


### PR DESCRIPTION
## Why

Release notes list `Claude Fable 5 ()` as a contributor because the `Co-Authored-By: Claude ... <noreply@anthropic.com>` commit trailers can never be resolved to a GitHub handle (JReleaser resolves handles via noreply-email parsing or public-email search, and neither applies here).

## What

Add `Claude` to `release.github.changelog.hide.contributors` in `jreleaser.yml`, alongside the existing `[bot]` and `GitHub` entries. Matching is substring-based, so all `Claude ...` co-author variants are covered.

Related context: the missing `(@rieckpil)` handle for the maintainer in past releases (e.g. v0.2.0) was a separate cause - commits authored with a private email that GitHub's user search cannot match - and is fixed outside the repo by committing with the `<id>+rieckpil@users.noreply.github.com` address going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)