### PR TITLE
fix(report): detect Spring Boot 4 slice annotations and prioritize specific test annotations

### DIFF
--- a/demo/spring-boot-4.0-maven/context-info.json
+++ b/demo/spring-boot-4.0-maven/context-info.json
@@ -1,4 +1,4 @@
 {
   "description": "Expected Spring Test Profiler metrics for this demo. Verified in CI against target/spring-test-profiler/results.json after the test suite ran.",
-  "expectedContextsCreated": 9
+  "expectedContextsCreated": 11
 }

--- a/demo/spring-boot-4.0-maven/pom.xml
+++ b/demo/spring-boot-4.0-maven/pom.xml
@@ -82,6 +82,12 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-restclient-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/demo/spring-boot-4.0-maven/src/test/java/digital/pragmatech/demo/BookControllerSliceIT.java
+++ b/demo/spring-boot-4.0-maven/src/test/java/digital/pragmatech/demo/BookControllerSliceIT.java
@@ -1,0 +1,54 @@
+package digital.pragmatech.demo;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import digital.pragmatech.demo.controller.BookController;
+import digital.pragmatech.demo.entity.Book;
+import digital.pragmatech.demo.entity.BookCategory;
+import digital.pragmatech.demo.service.BookService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Uses the Spring Boot 4 relocated {@code @WebMvcTest} slice annotation so the profiler report
+ * shows a WebMvcTest badge for this context (regression coverage for annotation detection).
+ */
+@WebMvcTest(BookController.class)
+class BookControllerSliceIT {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private BookService bookService;
+
+  @Test
+  void testGetAllBooks() throws Exception {
+    Book book = new Book("Clean Code", "Robert C. Martin", "978-0132350884",
+        new BigDecimal("34.99"), BookCategory.TECHNOLOGY);
+
+    when(bookService.findAll()).thenReturn(List.of(book));
+
+    mockMvc.perform(get("/api/books"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].title").value("Clean Code"));
+  }
+
+  @Test
+  void testGetBookCount() throws Exception {
+    when(bookService.count()).thenReturn(5L);
+
+    mockMvc.perform(get("/api/books/count"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").value(5));
+  }
+}

--- a/demo/spring-boot-4.0-maven/src/test/java/digital/pragmatech/demo/BookRepositorySliceIT.java
+++ b/demo/spring-boot-4.0-maven/src/test/java/digital/pragmatech/demo/BookRepositorySliceIT.java
@@ -1,0 +1,37 @@
+package digital.pragmatech.demo;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import digital.pragmatech.demo.entity.Book;
+import digital.pragmatech.demo.entity.BookCategory;
+import digital.pragmatech.demo.repository.BookRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Uses the Spring Boot 4 relocated {@code @DataJpaTest} slice annotation so the profiler report
+ * shows a DataJpaTest badge for this context (regression coverage for annotation detection).
+ */
+@DataJpaTest
+class BookRepositorySliceIT {
+
+  @Autowired
+  private BookRepository bookRepository;
+
+  @Test
+  void testFindByIsbn() {
+    Book book = new Book("Cosmos", "Carl Sagan", "978-0345539434",
+        new BigDecimal("14.99"), BookCategory.SCIENCE);
+
+    bookRepository.save(book);
+
+    Optional<Book> found = bookRepository.findByIsbn("978-0345539434");
+
+    assertThat(found).isPresent();
+    assertThat(found.get().getAuthor()).isEqualTo("Carl Sagan");
+  }
+}

--- a/src/main/java/digital/pragmatech/testing/util/TestAnnotationDetector.java
+++ b/src/main/java/digital/pragmatech/testing/util/TestAnnotationDetector.java
@@ -1,36 +1,65 @@
 package digital.pragmatech.testing.util;
 
-import java.lang.annotation.Annotation;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.MergedAnnotations;
 
 /**
- * Detects which Spring test annotation triggered the creation of a test context. Scans direct
- * annotations and one level of meta-annotations to catch composed annotations (e.g.,
- * {@code @MyIntegrationTest} meta-annotated with {@code @SpringBootTest}).
+ * Detects which Spring test annotation triggered the creation of a test context.
+ *
+ * <p>Annotations are matched by simple name (guarded by the {@code org.springframework.} package
+ * prefix) so both the Spring Boot 3.x package layout ({@code
+ * org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest}) and the relocated Spring
+ * Boot 4.x per-module packages ({@code org.springframework.boot.webmvc.test.autoconfigure
+ * .WebMvcTest}) are recognized.
+ *
+ * <p>The full type hierarchy is scanned (superclasses, interfaces, and meta-annotations at
+ * arbitrary depth), so annotations inherited from abstract base classes and custom composed
+ * annotations are detected. When several known annotations are present (e.g. an inherited
+ * {@code @ContextConfiguration} next to {@code @SpringBootTest}), the most specific one wins: slice
+ * annotations first, then {@code SpringBootTest}, with the generic {@code ContextConfiguration} as
+ * last-resort fallback.
  */
 public final class TestAnnotationDetector {
 
+  private static final Logger logger = LoggerFactory.getLogger(TestAnnotationDetector.class);
+
+  private static final String UNKNOWN = "Unknown";
+
+  private static final String SPRING_PACKAGE_PREFIX = "org.springframework.";
+
+  /** Simple annotation names mapped to display labels; iteration order defines priority. */
   private static final Map<String, String> KNOWN_ANNOTATIONS = new LinkedHashMap<>();
 
   static {
-    KNOWN_ANNOTATIONS.put("org.springframework.boot.test.context.SpringBootTest", "SpringBootTest");
-    KNOWN_ANNOTATIONS.put(
-        "org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest", "WebMvcTest");
-    KNOWN_ANNOTATIONS.put(
-        "org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest", "DataJpaTest");
-    KNOWN_ANNOTATIONS.put(
-        "org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest", "DataMongoTest");
-    KNOWN_ANNOTATIONS.put("org.springframework.boot.test.autoconfigure.jdbc.JdbcTest", "JdbcTest");
-    KNOWN_ANNOTATIONS.put("org.springframework.boot.test.autoconfigure.json.JsonTest", "JsonTest");
-    KNOWN_ANNOTATIONS.put(
-        "org.springframework.boot.test.autoconfigure.web.client.RestClientTest", "RestClientTest");
-    KNOWN_ANNOTATIONS.put(
-        "org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest", "WebFluxTest");
-    KNOWN_ANNOTATIONS.put(
-        "org.springframework.boot.test.autoconfigure.graphql.GraphQlTest", "GraphQlTest");
-    KNOWN_ANNOTATIONS.put(
-        "org.springframework.test.context.ContextConfiguration", "ContextConfiguration");
+    // Test slice annotations (most specific, highest priority)
+    KNOWN_ANNOTATIONS.put("WebMvcTest", "WebMvcTest");
+    KNOWN_ANNOTATIONS.put("WebFluxTest", "WebFluxTest");
+    KNOWN_ANNOTATIONS.put("DataJpaTest", "DataJpaTest");
+    KNOWN_ANNOTATIONS.put("DataJdbcTest", "DataJdbcTest");
+    KNOWN_ANNOTATIONS.put("DataMongoTest", "DataMongoTest");
+    KNOWN_ANNOTATIONS.put("DataRedisTest", "DataRedisTest");
+    KNOWN_ANNOTATIONS.put("DataCassandraTest", "DataCassandraTest");
+    KNOWN_ANNOTATIONS.put("DataElasticsearchTest", "DataElasticsearchTest");
+    KNOWN_ANNOTATIONS.put("DataNeo4jTest", "DataNeo4jTest");
+    KNOWN_ANNOTATIONS.put("DataR2dbcTest", "DataR2dbcTest");
+    KNOWN_ANNOTATIONS.put("DataLdapTest", "DataLdapTest");
+    KNOWN_ANNOTATIONS.put("JdbcTest", "JdbcTest");
+    KNOWN_ANNOTATIONS.put("JooqTest", "JooqTest");
+    KNOWN_ANNOTATIONS.put("JsonTest", "JsonTest");
+    KNOWN_ANNOTATIONS.put("RestClientTest", "RestClientTest");
+    KNOWN_ANNOTATIONS.put("WebServiceClientTest", "WebServiceClientTest");
+    KNOWN_ANNOTATIONS.put("WebServiceServerTest", "WebServiceServerTest");
+    KNOWN_ANNOTATIONS.put("GraphQlTest", "GraphQlTest");
+    // Full application context
+    KNOWN_ANNOTATIONS.put("SpringBootTest", "SpringBootTest");
+    // Generic fallback (lowest priority)
+    KNOWN_ANNOTATIONS.put("ContextConfiguration", "ContextConfiguration");
   }
 
   private TestAnnotationDetector() {}
@@ -43,29 +72,43 @@ public final class TestAnnotationDetector {
    */
   public static String detectTestAnnotationType(Class<?> testClass) {
     if (testClass == null) {
-      return "Unknown";
+      return UNKNOWN;
     }
 
-    // Check direct annotations
-    for (Annotation annotation : testClass.getAnnotations()) {
-      String annotationName = annotation.annotationType().getName();
-      String label = KNOWN_ANNOTATIONS.get(annotationName);
-      if (label != null) {
-        return label;
+    String label = detectInTypeHierarchy(testClass);
+    if (label != null) {
+      return label;
+    }
+
+    // @Nested test classes may rely on the enclosing class annotations
+    Class<?> enclosingClass = testClass.getEnclosingClass();
+    if (enclosingClass != null) {
+      return detectTestAnnotationType(enclosingClass);
+    }
+
+    return UNKNOWN;
+  }
+
+  private static String detectInTypeHierarchy(Class<?> testClass) {
+    Set<String> presentSimpleNames;
+    try {
+      presentSimpleNames =
+          MergedAnnotations.from(testClass, MergedAnnotations.SearchStrategy.TYPE_HIERARCHY)
+              .stream()
+              .map(annotation -> annotation.getType())
+              .filter(type -> type.getName().startsWith(SPRING_PACKAGE_PREFIX))
+              .map(Class::getSimpleName)
+              .collect(Collectors.toSet());
+    } catch (Throwable throwable) {
+      logger.debug("Failed to inspect annotations of {}", testClass.getName(), throwable);
+      return null;
+    }
+
+    for (Map.Entry<String, String> knownAnnotation : KNOWN_ANNOTATIONS.entrySet()) {
+      if (presentSimpleNames.contains(knownAnnotation.getKey())) {
+        return knownAnnotation.getValue();
       }
     }
-
-    // Check one level of meta-annotations (for composed annotations)
-    for (Annotation annotation : testClass.getAnnotations()) {
-      for (Annotation metaAnnotation : annotation.annotationType().getAnnotations()) {
-        String metaAnnotationName = metaAnnotation.annotationType().getName();
-        String label = KNOWN_ANNOTATIONS.get(metaAnnotationName);
-        if (label != null) {
-          return label;
-        }
-      }
-    }
-
-    return "Unknown";
+    return null;
   }
 }

--- a/src/test/java/digital/pragmatech/testing/util/TestAnnotationDetectorTest.java
+++ b/src/test/java/digital/pragmatech/testing/util/TestAnnotationDetectorTest.java
@@ -1,12 +1,121 @@
 package digital.pragmatech.testing.util;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import digital.pragmatech.testing.ContextCacheEntry;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TestAnnotationDetectorTest {
+
+  // Spring Boot 3.x package layout
+
+  @Test
+  void shouldDetectBoot3WebMvcTest() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(Boot3WebMvcClass.class))
+        .isEqualTo("WebMvcTest");
+  }
+
+  // Spring Boot 4.x relocated per-module packages
+
+  @Test
+  void shouldDetectBoot4WebMvcTest() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(Boot4WebMvcClass.class))
+        .isEqualTo("WebMvcTest");
+  }
+
+  @Test
+  void shouldDetectBoot4DataJpaTest() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(Boot4DataJpaClass.class))
+        .isEqualTo("DataJpaTest");
+  }
+
+  @Test
+  void shouldDetectBoot4RestClientTest() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(Boot4RestClientClass.class))
+        .isEqualTo("RestClientTest");
+  }
+
+  @Test
+  void shouldDetectBoot4DataJdbcTest() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(Boot4DataJdbcClass.class))
+        .isEqualTo("DataJdbcTest");
+  }
+
+  @Test
+  void shouldDetectSpringBootTest() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(SpringBootTestClass.class))
+        .isEqualTo("SpringBootTest");
+  }
+
+  // Priority: SpringBootTest must win over the generic ContextConfiguration
+
+  @Test
+  void shouldPreferSpringBootTestWhenContextConfigurationIsDeclaredFirst() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(ContextConfigBeforeSpringBoot.class))
+        .isEqualTo("SpringBootTest");
+  }
+
+  @Test
+  void shouldPreferSpringBootTestWhenContextConfigurationIsDeclaredLast() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(SpringBootBeforeContextConfig.class))
+        .isEqualTo("SpringBootTest");
+  }
+
+  // Inheritance from abstract base classes
+
+  @Test
+  void shouldDetectSpringBootTestInheritedFromAbstractBaseClass() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(ConcreteIntegrationTest.class))
+        .isEqualTo("SpringBootTest");
+  }
+
+  @Test
+  void shouldDetectSliceAnnotationInheritedFromAbstractBaseClass() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(ConcreteWebMvcTest.class))
+        .isEqualTo("WebMvcTest");
+  }
+
+  // Composed / meta-annotations
+
+  @Test
+  void shouldDetectComposedAnnotation() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(ComposedAnnotationClass.class))
+        .isEqualTo("SpringBootTest");
+  }
+
+  @Test
+  void shouldDetectDeeplyComposedAnnotation() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(DeeplyComposedAnnotationClass.class))
+        .isEqualTo("SpringBootTest");
+  }
+
+  // @Nested test classes
+
+  @Test
+  void shouldDetectAnnotationFromEnclosingClassForNestedTests() {
+    assertThat(
+            TestAnnotationDetector.detectTestAnnotationType(
+                SpringBootTestClass.NestedTestClass.class))
+        .isEqualTo("SpringBootTest");
+  }
+
+  // Package guard
+
+  @Test
+  void shouldNotDetectNonSpringAnnotationWithKnownSimpleName() {
+    assertThat(TestAnnotationDetector.detectTestAnnotationType(DecoyWebMvcClass.class))
+        .isEqualTo("Unknown");
+  }
+
+  // Existing behavior
 
   @Test
   void shouldDetectContextConfiguration() {
@@ -62,6 +171,67 @@ class TestAnnotationDetectorTest {
   }
 
   // Test fixture classes
+
+  @org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+  static class Boot3WebMvcClass {}
+
+  @org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+  static class Boot4WebMvcClass {}
+
+  @org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+  static class Boot4DataJpaClass {}
+
+  @org.springframework.boot.restclient.test.autoconfigure.RestClientTest
+  static class Boot4RestClientClass {}
+
+  @org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest
+  static class Boot4DataJdbcClass {}
+
+  @SpringBootTest
+  static class SpringBootTestClass {
+
+    class NestedTestClass {}
+  }
+
+  @ContextConfiguration(classes = Object.class)
+  @SpringBootTest
+  static class ContextConfigBeforeSpringBoot {}
+
+  @SpringBootTest
+  @ContextConfiguration(classes = Object.class)
+  static class SpringBootBeforeContextConfig {}
+
+  @ContextConfiguration(classes = Object.class)
+  @SpringBootTest
+  abstract static class AbstractIntegrationTest {}
+
+  static class ConcreteIntegrationTest extends AbstractIntegrationTest {}
+
+  @org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+  abstract static class AbstractWebMvcTest {}
+
+  static class ConcreteWebMvcTest extends AbstractWebMvcTest {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Inherited
+  @SpringBootTest
+  @interface MyIntegrationTest {}
+
+  @MyIntegrationTest
+  static class ComposedAnnotationClass {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Inherited
+  @MyIntegrationTest
+  @interface OuterComposedTest {}
+
+  @OuterComposedTest
+  static class DeeplyComposedAnnotationClass {}
+
+  @digital.pragmatech.testing.util.fixture.WebMvcTest
+  static class DecoyWebMvcClass {}
 
   @ContextConfiguration(classes = Object.class)
   static class ContextConfigClass {}

--- a/src/test/java/digital/pragmatech/testing/util/fixture/WebMvcTest.java
+++ b/src/test/java/digital/pragmatech/testing/util/fixture/WebMvcTest.java
@@ -1,0 +1,16 @@
+package digital.pragmatech.testing.util.fixture;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Decoy annotation with a known slice simple name but outside the {@code org.springframework.}
+ * package. Must NOT be detected.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface WebMvcTest {}

--- a/src/test/java/org/springframework/boot/data/jdbc/test/autoconfigure/DataJdbcTest.java
+++ b/src/test/java/org/springframework/boot/data/jdbc/test/autoconfigure/DataJdbcTest.java
@@ -1,0 +1,13 @@
+package org.springframework.boot.data.jdbc.test.autoconfigure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Test fixture mirroring the relocated Spring Boot 4.x slice annotation FQCN. */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface DataJdbcTest {}

--- a/src/test/java/org/springframework/boot/data/jpa/test/autoconfigure/DataJpaTest.java
+++ b/src/test/java/org/springframework/boot/data/jpa/test/autoconfigure/DataJpaTest.java
@@ -1,0 +1,13 @@
+package org.springframework.boot.data.jpa.test.autoconfigure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Test fixture mirroring the relocated Spring Boot 4.x slice annotation FQCN. */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface DataJpaTest {}

--- a/src/test/java/org/springframework/boot/restclient/test/autoconfigure/RestClientTest.java
+++ b/src/test/java/org/springframework/boot/restclient/test/autoconfigure/RestClientTest.java
@@ -1,0 +1,13 @@
+package org.springframework.boot.restclient.test.autoconfigure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Test fixture mirroring the relocated Spring Boot 4.x slice annotation FQCN. */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface RestClientTest {}

--- a/src/test/java/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTest.java
+++ b/src/test/java/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTest.java
@@ -1,0 +1,13 @@
+package org.springframework.boot.test.autoconfigure.web.servlet;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Test fixture mirroring the Spring Boot 3.x slice annotation FQCN. */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface WebMvcTest {}

--- a/src/test/java/org/springframework/boot/test/context/SpringBootTest.java
+++ b/src/test/java/org/springframework/boot/test/context/SpringBootTest.java
@@ -1,0 +1,16 @@
+package org.springframework.boot.test.context;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Test fixture mirroring the real Spring Boot annotation (same FQCN in Boot 3.x and 4.x). The real
+ * artifact is not on the test classpath, so detection tests use this stand-in.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface SpringBootTest {}

--- a/src/test/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTest.java
+++ b/src/test/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTest.java
@@ -1,0 +1,13 @@
+package org.springframework.boot.webmvc.test.autoconfigure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Test fixture mirroring the relocated Spring Boot 4.x slice annotation FQCN. */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface WebMvcTest {}


### PR DESCRIPTION
## Problem

Reports generated for Spring Boot 4 projects show wrong or missing test-type badges:

- On a Spring Boot 4.0.2 project (testing-spring-boot-applications-masterclass), every slice test context (`@WebMvcTest`, `@DataJpaTest`, `@RestClientTest`) was labeled **Unknown**.
- Tests inheriting `@SpringBootTest` from an abstract base class that declares `@ContextConfiguration` first were labeled **ContextConfiguration** instead of **SpringBootTest**.

## Root causes

Both defects live in `TestAnnotationDetector`:

1. The detector matched hardcoded Spring Boot 3.x FQCNs. Spring Boot 4 relocated slice annotations to per-module packages (e.g. `org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest`, `org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest`), so no slice annotation ever matched. Only `@SpringBootTest` kept its package and was still detected.
2. The first known annotation in declaration order won. A base class declaring `@ContextConfiguration` before `@SpringBootTest` therefore labeled all subclasses as `ContextConfiguration`.

## Fix

- Match by simple annotation name guarded by the `org.springframework.` package prefix - covers Boot 3.x and 4.x layouts without enumerating every package, while a decoy annotation with the same simple name outside Spring packages stays undetected.
- Select by priority instead of declaration order: slice annotations first, then `SpringBootTest`, with the generic `ContextConfiguration` as last-resort fallback.
- Scan the full type hierarchy via Spring's `MergedAnnotations` (`SearchStrategy.TYPE_HIERARCHY`): handles annotations inherited from abstract base classes, composed annotations at arbitrary depth, and `@Nested` classes via an enclosing-class fallback.
- Extend the known slice list (DataJdbcTest, JooqTest, DataRedisTest, DataCassandraTest, DataElasticsearchTest, DataNeo4jTest, DataR2dbcTest, DataLdapTest, WebServiceClientTest, WebServiceServerTest).

## Regression protection

- **Unit tests** (21 total): Boot 3 and Boot 4 slice packages, priority with both declaration orders, inheritance from abstract base classes, composed annotations at depth 1 and 2, `@Nested` classes, non-Spring decoy annotation, plus the existing cases. Fixture annotations mirroring the exact Spring FQCNs live under `src/test/java/org/springframework/...` since the real artifacts are not on the profiler test classpath.
- **Boot 4 demo end-to-end coverage**: `demo/spring-boot-4.0-maven` previously only used `@SpringBootTest`, which is why this regression went uncaught. New `BookControllerSliceIT` (relocated `@WebMvcTest`) and `BookRepositorySliceIT` (relocated `@DataJpaTest`) exercise the Boot 4 detection path in CI; `expectedContextsCreated` raised 9 -> 11.

## Verification

- `./mvnw clean install`: 117 tests green, spotless clean.
- Boot 4 demo run: badges now show `1 DataJpaTest, 1 WebMvcTest, 7 SpringBootTest` - no `Unknown`, no spurious `ContextConfiguration`; `verify-profiler-json.sh` passes with 11 contexts.
- Boot 3.5 demo regression run: badges unchanged and correct, JSON verification passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)