### PR TITLE
fix(core): avoid ClassCastException with Spring Modulith's event multicaster

### DIFF
--- a/demo/spring-boot-4.0-maven/pom.xml
+++ b/demo/spring-boot-4.0-maven/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.0-RC2</version>
+    <version>4.1.0</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
@@ -22,7 +22,20 @@
 
   <properties>
     <java.version>21</java.version>
+    <spring-modulith.version>2.1.0</spring-modulith.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.modulith</groupId>
+        <artifactId>spring-modulith-bom</artifactId>
+        <version>${spring-modulith.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -61,6 +74,17 @@
       <scope>runtime</scope>
     </dependency>
 
+    <!-- Spring Modulith with the JDBC-backed event publication registry (see issue #58) -->
+    <dependency>
+      <groupId>org.springframework.modulith</groupId>
+      <artifactId>spring-modulith-starter-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.modulith</groupId>
+      <artifactId>spring-modulith-starter-jdbc</artifactId>
+    </dependency>
+
     <!-- Test dependencies, now more modular in Spring Boot 4.0  -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -89,6 +113,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-restclient-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.modulith</groupId>
+      <artifactId>spring-modulith-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/demo/spring-boot-4.0-maven/src/main/java/digital/pragmatech/demo/DemoApplication.java
+++ b/demo/spring-boot-4.0-maven/src/main/java/digital/pragmatech/demo/DemoApplication.java
@@ -7,8 +7,10 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync // required for @ApplicationModuleListener, which is meta-annotated with @Async
 @EnableScheduling
 @SpringBootApplication
 public class DemoApplication implements CommandLineRunner {

--- a/demo/spring-boot-4.0-maven/src/main/java/digital/pragmatech/demo/notification/BookCreatedNotifier.java
+++ b/demo/spring-boot-4.0-maven/src/main/java/digital/pragmatech/demo/notification/BookCreatedNotifier.java
@@ -1,0 +1,28 @@
+package digital.pragmatech.demo.notification;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import digital.pragmatech.demo.service.BookCreatedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BookCreatedNotifier {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BookCreatedNotifier.class);
+
+  private final List<String> notifiedIsbns = new CopyOnWriteArrayList<>();
+
+  @ApplicationModuleListener
+  void on(BookCreatedEvent event) {
+    LOG.info("New book created: {} ({})", event.title(), event.isbn());
+    notifiedIsbns.add(event.isbn());
+  }
+
+  public List<String> notifiedIsbns() {
+    return List.copyOf(notifiedIsbns);
+  }
+}

--- a/demo/spring-boot-4.0-maven/src/main/java/digital/pragmatech/demo/service/BookCreatedEvent.java
+++ b/demo/spring-boot-4.0-maven/src/main/java/digital/pragmatech/demo/service/BookCreatedEvent.java
@@ -1,0 +1,3 @@
+package digital.pragmatech.demo.service;
+
+public record BookCreatedEvent(Long bookId, String isbn, String title) {}

--- a/demo/spring-boot-4.0-maven/src/main/java/digital/pragmatech/demo/service/BookService.java
+++ b/demo/spring-boot-4.0-maven/src/main/java/digital/pragmatech/demo/service/BookService.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import digital.pragmatech.demo.entity.Book;
 import digital.pragmatech.demo.entity.BookCategory;
 import digital.pragmatech.demo.repository.BookRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,16 +16,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class BookService {
 
   private final BookRepository bookRepository;
+  private final ApplicationEventPublisher eventPublisher;
 
-  public BookService(BookRepository bookRepository) {
+  public BookService(BookRepository bookRepository, ApplicationEventPublisher eventPublisher) {
     this.bookRepository = bookRepository;
+    this.eventPublisher = eventPublisher;
   }
 
   public Book createBook(Book book) {
     if (bookRepository.existsByIsbn(book.getIsbn())) {
       throw new IllegalArgumentException("Book with ISBN " + book.getIsbn() + " already exists");
     }
-    return bookRepository.save(book);
+    Book savedBook = bookRepository.save(book);
+    eventPublisher.publishEvent(
+      new BookCreatedEvent(savedBook.getId(), savedBook.getIsbn(), savedBook.getTitle()));
+    return savedBook;
   }
 
   @Transactional(readOnly = true)

--- a/demo/spring-boot-4.0-maven/src/main/resources/application.properties
+++ b/demo/spring-boot-4.0-maven/src/main/resources/application.properties
@@ -9,3 +9,5 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
 # H2 Console (for development)
 spring.h2.console.enabled=true
+# Spring Modulith: create the EVENT_PUBLICATION table for the JDBC event registry
+spring.modulith.events.jdbc.schema-initialization.enabled=true

--- a/demo/spring-boot-4.0-maven/src/test/java/digital/pragmatech/demo/BookEventPublicationIT.java
+++ b/demo/spring-boot-4.0-maven/src/test/java/digital/pragmatech/demo/BookEventPublicationIT.java
@@ -1,0 +1,54 @@
+package digital.pragmatech.demo;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+
+import digital.pragmatech.demo.entity.Book;
+import digital.pragmatech.demo.entity.BookCategory;
+import digital.pragmatech.demo.notification.BookCreatedNotifier;
+import digital.pragmatech.demo.service.BookService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that Spring Modulith's JDBC-backed event publication registry processes a domain event
+ * end-to-end: BookService publishes a BookCreatedEvent on commit and the @ApplicationModuleListener
+ * in the notification module handles it asynchronously.
+ *
+ * <p>Shares the context configuration of {@link GoodIT} (cache HIT). Deliberately
+ * NOT @Transactional: @ApplicationModuleListener only fires after the transaction commits, and
+ * BookService.createBook commits its own transaction.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class BookEventPublicationIT {
+
+  @Autowired
+  private BookService bookService;
+
+  @Autowired
+  private BookCreatedNotifier bookCreatedNotifier;
+
+  @AfterEach
+  void cleanUp() {
+    // This test commits for real (no rollback), so remove the book to keep the shared
+    // context's database consistent for other test classes (e.g. GoodIT's count assertions)
+    bookService.deleteByIsbn("978-1098157630");
+  }
+
+  @Test
+  void bookCreationPublishesEventToModuleListener() {
+    bookService.createBook(new Book("Modular Monoliths", "Kamil Grzybek", "978-1098157630",
+      new BigDecimal("39.99"), BookCategory.TECHNOLOGY));
+
+    await().atMost(Duration.ofSeconds(10))
+      .untilAsserted(() ->
+        assertTrue(bookCreatedNotifier.notifiedIsbns().contains("978-1098157630")));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,9 @@
     <junit-jupiter.version>6.0.2</junit-jupiter.version>
     <assertj.version>3.27.6</assertj.version>
     <awaitility.version>4.3.0</awaitility.version>
+    <!-- Modulith 2.0.x matches the Spring Framework 7.0.x / Boot 4.0.x line used above -->
+    <spring-modulith.version>2.0.7</spring-modulith.version>
+    <h2.version>2.4.240</h2.version>
 
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
@@ -123,6 +126,27 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>${assertj.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Regression coverage for GitHub issue #58: Spring Modulith's
+         PersistentApplicationEventMulticaster must tolerate the profiler's listeners -->
+    <dependency>
+      <groupId>org.springframework.modulith</groupId>
+      <artifactId>spring-modulith-starter-jdbc</artifactId>
+      <version>${spring-modulith.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jdbc</artifactId>
+      <version>${spring-boot.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>${h2.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/digital/pragmatech/testing/SpringTestProfilerListener.java
+++ b/src/main/java/digital/pragmatech/testing/SpringTestProfilerListener.java
@@ -270,20 +270,44 @@ public class SpringTestProfilerListener extends AbstractTestExecutionListener {
     ContextCache contextCache = SpringContextCacheAccessor.getContextCache(testContext);
 
     configurableContext.addApplicationListener(
-        (ApplicationListener<ContextClosedEvent>)
-            event -> {
-              try {
-                closeListenerRegistered.remove(event.getApplicationContext());
-                if (reportGenerationStarted || isJvmShutdownInProgress()) {
-                  return;
-                }
-                ContextRemovalReason reason =
-                    ContextRemovalDetector.inferRemovalReason(contextCache);
-                contextCacheTracker.recordContextRemoval(mergedConfig, Instant.now(), reason);
-              } catch (Exception e) {
-                logger.debug("Failed to record context removal", e);
-              }
-            });
+        new ContextClosedRemovalListener(mergedConfig, contextCache));
+  }
+
+  /**
+   * Records the removal of a context from Spring's context cache when it is closed.
+   *
+   * <p>Deliberately a concrete class rather than a lambda: Spring resolves the declared generic
+   * event type (via GenericApplicationListenerAdapter), so this listener is only ever invoked for
+   * ContextClosedEvent. A lambda's generic event type cannot be resolved, causing it to be invoked
+   * for ALL events; event multicasters without a defensive ClassCastException catch (e.g. Spring
+   * Modulith's PersistentApplicationEventMulticaster) then fail when the test framework publishes
+   * other events such as AfterTestClassEvent (GitHub issue #58).
+   */
+  static final class ContextClosedRemovalListener
+      implements ApplicationListener<ContextClosedEvent> {
+
+    private final MergedContextConfiguration mergedConfig;
+    private final ContextCache contextCache;
+
+    ContextClosedRemovalListener(
+        MergedContextConfiguration mergedConfig, ContextCache contextCache) {
+      this.mergedConfig = mergedConfig;
+      this.contextCache = contextCache;
+    }
+
+    @Override
+    public void onApplicationEvent(@NonNull ContextClosedEvent event) {
+      try {
+        closeListenerRegistered.remove(event.getApplicationContext());
+        if (reportGenerationStarted || isJvmShutdownInProgress()) {
+          return;
+        }
+        ContextRemovalReason reason = ContextRemovalDetector.inferRemovalReason(contextCache);
+        contextCacheTracker.recordContextRemoval(mergedConfig, Instant.now(), reason);
+      } catch (Exception e) {
+        logger.debug("Failed to record context removal", e);
+      }
+    }
   }
 
   /**

--- a/src/test/java/digital/pragmatech/testing/ContextClosedRemovalListenerTest.java
+++ b/src/test/java/digital/pragmatech/testing/ContextClosedRemovalListenerTest.java
@@ -1,0 +1,33 @@
+package digital.pragmatech.testing;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.GenericApplicationListenerAdapter;
+import org.springframework.core.ResolvableType;
+import org.springframework.test.context.event.AfterTestClassEvent;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for GitHub issue #58: the context-removal listener must declare a resolvable
+ * ContextClosedEvent type so event multicasters never deliver unrelated events (e.g. Spring's
+ * AfterTestClassEvent) to it. A lambda's generic event type cannot be resolved, making it match
+ * every event type; Spring Modulith's PersistentApplicationEventMulticaster invokes listeners
+ * without catching ClassCastException, so an unresolvable listener breaks test builds.
+ */
+class ContextClosedRemovalListenerTest {
+
+  @Test
+  void supportsOnlyContextClosedEvents() {
+    var listener = new SpringTestProfilerListener.ContextClosedRemovalListener(null, null);
+    var adapter = new GenericApplicationListenerAdapter(listener);
+
+    assertTrue(
+        adapter.supportsEventType(ResolvableType.forClass(ContextClosedEvent.class)),
+        "Listener must handle ContextClosedEvent");
+    assertFalse(
+        adapter.supportsEventType(ResolvableType.forClass(AfterTestClassEvent.class)),
+        "Listener must not be invoked for test events (issue #58)");
+  }
+}

--- a/src/test/java/digital/pragmatech/testing/SpringModulithCompatibilityTest.java
+++ b/src/test/java/digital/pragmatech/testing/SpringModulithCompatibilityTest.java
@@ -1,0 +1,43 @@
+package digital.pragmatech.testing;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.modulith.events.support.PersistentApplicationEventMulticaster;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Regression test for GitHub issue #58: with Spring Modulith's JDBC event publication registry
+ * active, the context's event multicaster is Modulith's PersistentApplicationEventMulticaster,
+ * which invokes listeners WITHOUT the ClassCastException safety net of Spring's default
+ * multicaster. The test framework publishes test events (PrepareTestInstanceEvent,
+ * AfterTestClassEvent, ...) into this context because the profiler registers context listeners; if
+ * any profiler listener has an unresolvable event type (e.g. a mistyped lambda), this test class
+ * errors with "AfterTestClassEvent cannot be cast to ContextClosedEvent" in afterTestClass.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SpringModulithCompatibilityTest.ModulithConfig.class)
+class SpringModulithCompatibilityTest {
+
+  @Autowired private ApplicationContext applicationContext;
+
+  @Test
+  void modulithEventMulticasterIsActive() {
+    // Guard: the scenario is only covered while Modulith replaces the default multicaster
+    assertInstanceOf(
+        PersistentApplicationEventMulticaster.class,
+        applicationContext.getBean(
+            AbstractApplicationContext.APPLICATION_EVENT_MULTICASTER_BEAN_NAME));
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  @EnableAutoConfiguration
+  static class ModulithConfig {}
+}


### PR DESCRIPTION
Fixes #58

## Root cause

`SpringTestProfilerListener` registered its context-removal listener as a **lambda** cast to `ApplicationListener<ContextClosedEvent>`. Spring cannot resolve a lambda's generic event type, so the listener was treated as matching *every* event type, and the lambda's synthetic `checkcast ContextClosedEvent` blew up for anything else.

- With Spring's default `SimpleApplicationEventMulticaster` this stayed hidden: `doInvokeListener` deliberately swallows `ClassCastException`s from lambda-defined listeners.
- Spring Modulith's `PersistentApplicationEventMulticaster` (active once the event publication registry is on the classpath, e.g. `spring-modulith-starter-jdbc`) invokes `listener.onApplicationEvent(event)` directly with no such safety net.
- The profiler's `ContextDiagnosticApplicationInitializer` registers a context listener, which makes `EventPublishingTestExecutionListener` publish test events into the context - so every `AfterTestClassEvent`, `PrepareTestInstanceEvent` (and Boot 4.1's `ContextPausedEvent`/`ContextRestartedEvent`) crashed the build.

## Fix

Replace the lambda with a static nested `ContextClosedRemovalListener` class (verbatim body move). A concrete class has a resolvable declared event type, so multicasters only ever deliver `ContextClosedEvent` to it. The Javadoc documents why it must not become a lambda again.

## Regression coverage

- `ContextClosedRemovalListenerTest` - asserts via `GenericApplicationListenerAdapter` (the exact mechanism multicasters use) that the listener supports `ContextClosedEvent` but not `AfterTestClassEvent`.
- `SpringModulithCompatibilityTest` - boots a context with Modulith's JDBC event registry (test-scoped Modulith 2.0.7 + H2, matching the core's Framework 7.0.x line) and asserts `PersistentApplicationEventMulticaster` is really the active multicaster.
- The `spring-boot-4.0-maven` demo now uses Spring Boot 4.1.0 + Spring Modulith 2.1.0 with the JDBC event registry and sample module code (`BookCreatedEvent` published by `BookService`, handled by an `@ApplicationModuleListener` in a new `notification` package). Before the fix this demo failed with 19 errors matching the issue exactly; the new `BookEventPublicationIT` also proves the event registry processes events end-to-end.

## Verification

- Core `./mvnw verify`: 119 tests green (incl. `DirtiesContextRemovalTrackingTest`, proving removal recording is unchanged)
- Demo `./mvnw clean verify`: BUILD SUCCESS, 20 ITs green
- `.github/scripts/verify-profiler-json.sh`: passes with `contextsCreated=11` (the new IT reuses `GoodIT`'s context and cleans up its committed data)
- HTML report still records `@DirtiesContext` removals under the Modulith multicaster

Also in this PR: the visual regression check (run-local.sh + workflow) now renders its reports from the `spring-boot-4.0-maven` demo instead of `spring-boot-3.5-maven`; its baseline leg tolerates test failures since the released 0.2.3 profiler fails the Modulith demo (the report is generated regardless).

Follow-up idea (out of scope): rename the demo directory to `spring-boot-4.1-maven` since it now runs Boot 4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)